### PR TITLE
fix: update build workflow to improve mac builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,6 @@ jobs:
         run: |
           python -m PyInstaller --noconfirm --clean --windowed --onefile --name crush `
             --icon crush.ico `
-            --collect-all PySide6 `
             --collect-all magic `
             --collect-all pillow_heif `
             --collect-all pillow_jxl `
@@ -287,7 +286,7 @@ jobs:
 
       - name: Package artifact (macOS → ZIP)
         if: runner.os == 'macOS'
-        run: ditto -c -k --sequesterRsrc dist/crush.app "${MACOS_ARTIFACT}"
+        run: ditto -c -k --sequesterRsrc --keepParent dist/crush.app "${MACOS_ARTIFACT}"
 
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -184,7 +184,6 @@ jobs:
         run: |
           python -m PyInstaller --noconfirm --clean --windowed --name crush \
             --icon crush.icns \
-            --collect-all PySide6 \
             --collect-all magic \
             --collect-all pillow_heif \
             --collect-all pillow_jxl \
@@ -304,7 +303,7 @@ jobs:
 
       - name: Package artifact (macOS → ZIP)
         if: runner.os == 'macOS'
-        run: ditto -c -k --sequesterRsrc dist/crush.app "${MACOS_ARTIFACT_NAME}-${BUILD_ID}.zip"
+        run: ditto -c -k --sequesterRsrc --keepParent dist/crush.app "${MACOS_ARTIFACT_NAME}-${BUILD_ID}.zip"
 
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
1. remove `--collect-all PySide6` from `pyinstaller`
with this, the built app was throwing a `AttributeError: module 'pkg_resources' has no attribute 'NullProvider'` error

2. add `--keepParent` to `ditto`
without this, the `crush.app` folder was getting removed, so the zip file when extracted was not showing as a proper app

fixes applied to both `build` and `nightly` workflows. builds tested on Mac, but not on windows or linux.