### PR TITLE
fix: improve side scrolling behavior

### DIFF
--- a/crush/ui/fs_panel.py
+++ b/crush/ui/fs_panel.py
@@ -28,6 +28,7 @@ from crush.core.session import Session
 from crush.core.vfs import VFS, VFSNode, DirectoryVFS
 from crush.core.magic import detect_fast_label
 from crush.core.work_priority import background_io
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 _IMAGE_TYPE_LABELS: frozenset[str] = frozenset({
     "image", "heic", "heif", "avif", "jxl",
@@ -163,6 +164,7 @@ class FilesystemPanel(QWidget):
         self._tree.setUniformRowHeights(True)
         self._tree.setAlternatingRowColors(True)
         self._tree.setSortingEnabled(False)
+        install_horizontal_wheel_scroll(self._tree)
         self._tree.setColumnWidth(0, 160)
         self._tree.setColumnWidth(1, 65)
         self._tree.setColumnWidth(2, 60)
@@ -181,6 +183,7 @@ class FilesystemPanel(QWidget):
         self._search_view.setUniformRowHeights(True)
         self._search_view.setAlternatingRowColors(True)
         self._search_view.setSortingEnabled(True)
+        install_horizontal_wheel_scroll(self._search_view)
         self._search_view.setColumnWidth(0, 160)
         self._search_view.setColumnWidth(1, 200)
         self._search_view.setColumnWidth(2, 65)

--- a/crush/ui/props_panel.py
+++ b/crush/ui/props_panel.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 )
 
 from crush.core.vfs import VFSNode
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 _SELECTABLE = (
     Qt.TextInteractionFlag.TextSelectableByMouse
@@ -31,6 +32,7 @@ class PropertiesPanel(QScrollArea):
         self._layout.setContentsMargins(8, 8, 8, 8)
         self._layout.setSpacing(4)
         self.setWidget(self._container)
+        install_horizontal_wheel_scroll(self, smooth_item_scroll=False)
 
     def clear(self) -> None:
         while self._layout.rowCount():

--- a/crush/ui/search_panel.py
+++ b/crush/ui/search_panel.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 )
 
 from crush.core.vfs import VFS, VFSNode
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 _ROLE_NODE = Qt.ItemDataRole.UserRole + 1
 _ROLE_VFS = Qt.ItemDataRole.UserRole + 2
@@ -217,6 +218,7 @@ class SearchPanel(QWidget):
         self._table.setAlternatingRowColors(True)
         self._table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
         self._table.setSelectionMode(QTableView.SelectionMode.SingleSelection)
+        install_horizontal_wheel_scroll(self._table)
         self._table.verticalHeader().setDefaultSectionSize(20)
         self._table.verticalHeader().setVisible(False)
         self._table.horizontalHeader().setStretchLastSection(False)

--- a/crush/ui/wheel_scroll.py
+++ b/crush/ui/wheel_scroll.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Wheel scrolling helpers shared by Qt scroll areas."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtWidgets import QAbstractItemView, QAbstractScrollArea
+
+
+_FILTER_ATTR = "_crush_horizontal_wheel_scroll_filter"
+
+
+def handle_shift_wheel_horizontal_scroll(
+    scroll_area: QAbstractScrollArea, event: object
+) -> bool:
+    """Map Shift + vertical wheel events to horizontal scrollbar movement."""
+    if not (hasattr(event, "modifiers") and hasattr(event, "angleDelta")):
+        return False
+    if not event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
+        return False
+
+    hbar = scroll_area.horizontalScrollBar()
+    if hbar.minimum() == hbar.maximum():
+        return False
+
+    delta = 0
+    if hasattr(event, "pixelDelta"):
+        pixel_delta = event.pixelDelta()
+        delta = pixel_delta.x() or pixel_delta.y()
+    if not delta:
+        angle_delta = event.angleDelta()
+        delta = (angle_delta.x() or angle_delta.y()) // 2
+    if not delta:
+        return False
+
+    hbar.setValue(hbar.value() - delta)
+    if hasattr(event, "accept"):
+        event.accept()
+    return True
+
+
+class _HorizontalWheelScrollFilter(QObject):
+    def __init__(
+        self,
+        scroll_area: QAbstractScrollArea,
+        on_wheel: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__(scroll_area)
+        self._scroll_area = scroll_area
+        self._on_wheel = on_wheel
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Wheel:
+            if self._on_wheel is not None:
+                self._on_wheel()
+            if handle_shift_wheel_horizontal_scroll(self._scroll_area, event):
+                return True
+        return super().eventFilter(watched, event)
+
+
+def install_horizontal_wheel_scroll(
+    scroll_area: QAbstractScrollArea,
+    *,
+    on_wheel: Callable[[], None] | None = None,
+    smooth_item_scroll: bool = True,
+) -> None:
+    """Enable cross-platform Shift-wheel horizontal scrolling for a scroll area."""
+    existing = getattr(scroll_area, _FILTER_ATTR, None)
+    if existing is not None:
+        return
+
+    if smooth_item_scroll and isinstance(scroll_area, QAbstractItemView):
+        scroll_area.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+
+    event_filter = _HorizontalWheelScrollFilter(scroll_area, on_wheel)
+    scroll_area.installEventFilter(event_filter)
+    scroll_area.viewport().installEventFilter(event_filter)
+    setattr(scroll_area, _FILTER_ATTR, event_filter)

--- a/crush/viewers/blob_inspector.py
+++ b/crush/viewers/blob_inspector.py
@@ -33,6 +33,7 @@ from crush.core.formatters import (
     try_plist_text,
     try_xml_text,
 )
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 # Column layout of bytes_to_hexview output, e.g. "0000000a: 48 65 6c  Hel"
 _BLOB_HEX_START = 10
@@ -389,11 +390,13 @@ class _BlobPanel(QWidget):
         self._viewer = _BlobViewerEdit(self)
         self._viewer.setReadOnly(True)
         self._viewer.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        install_horizontal_wheel_scroll(self._viewer, smooth_item_scroll=False)
         self._stack.addWidget(self._viewer)
 
         self._img_scroll = QScrollArea()
         self._img_scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._img_scroll.setWidgetResizable(False)
+        install_horizontal_wheel_scroll(self._img_scroll, smooth_item_scroll=False)
         self._img_label = QLabel()
         self._img_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._img_scroll.setWidget(self._img_label)

--- a/crush/viewers/hex_viewer.py
+++ b/crush/viewers/hex_viewer.py
@@ -16,6 +16,8 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QContextMenuEvent, QFont
 
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
+
 
 _BYTES_PER_ROW = 16
 _PAGE_BYTES = 1024 * 256  # 256 KB per page
@@ -120,6 +122,7 @@ class HexViewer(QWidget):
         self._text = _HexPlainTextEdit(self)
         self._text.setReadOnly(True)
         self._text.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        install_horizontal_wheel_scroll(self._text, smooth_item_scroll=False)
 
         font = QFont("Courier New", 10)
         font.setStyleHint(QFont.StyleHint.Monospace)

--- a/crush/viewers/image_viewer.py
+++ b/crush/viewers/image_viewer.py
@@ -18,6 +18,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
+
 
 _exotic_registered = False
 
@@ -115,6 +117,7 @@ class ImageViewer(QWidget):
         self._scroll = QScrollArea()
         self._scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._scroll.setWidgetResizable(False)
+        install_horizontal_wheel_scroll(self._scroll, smooth_item_scroll=False)
         self._scroll.viewport().setMouseTracking(True)
 
         self._image_label = QLabel()

--- a/crush/viewers/leveldb_viewer.py
+++ b/crush/viewers/leveldb_viewer.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 from crush.viewers.hex_viewer import HexViewer
 from crush.viewers.table_viewer import BlobInspector
 from crush.viewers.tree_viewer import TreeViewer
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 # Raw bytes stored alongside display text via custom item data roles
 _KEY_BYTES_ROLE = Qt.ItemDataRole.UserRole + 1
@@ -177,6 +178,7 @@ class LevelDbRecordsWidget(QWidget):
         self._table.setSelectionMode(QTableView.SelectionMode.SingleSelection)
         self._table.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
         self._table.setSortingEnabled(True)
+        install_horizontal_wheel_scroll(self._table)
         self._table.horizontalHeader().setStretchLastSection(True)
         self._table.resizeColumnsToContents()
         self._table.selectionModel().currentRowChanged.connect(self._on_row_changed)
@@ -405,6 +407,7 @@ class LevelDbViewer(QWidget):
         table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
         table.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
         table.setSortingEnabled(True)
+        install_horizontal_wheel_scroll(table)
         table.horizontalHeader().setStretchLastSection(True)
         table.resizeColumnsToContents()
 
@@ -438,6 +441,7 @@ class LevelDbViewer(QWidget):
         text_view = QPlainTextEdit()
         text_view.setReadOnly(True)
         text_view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        install_horizontal_wheel_scroll(text_view, smooth_item_scroll=False)
         text_view.document().setDefaultFont(QFont("Monospace", 9))
         text_view.setPlainText(content)
         layout.addWidget(text_view)

--- a/crush/viewers/multi_log_viewer.py
+++ b/crush/viewers/multi_log_viewer.py
@@ -86,6 +86,7 @@ import time
 from crush.core.log_db import FilterSpec, LogDatabase, _INSERT_SQL, _ts_to_unix, _unix_to_ts
 
 from crush.core.vfs import VFS, VFSNode
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 _log = logging.getLogger("crush")
 
@@ -315,6 +316,7 @@ class DefineFormatDialog(QDialog):
         self._preview = QTextEdit()
         self._preview.setReadOnly(True)
         self._preview.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
+        install_horizontal_wheel_scroll(self._preview, smooth_item_scroll=False)
         font = self._preview.font()
         font.setFamily("monospace")
         font.setPointSize(10)
@@ -1301,6 +1303,7 @@ class MultiLogViewer(QWidget):
         self._table.setAlternatingRowColors(True)
         self._table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
         self._table.setSelectionMode(QTableView.SelectionMode.SingleSelection)
+        install_horizontal_wheel_scroll(self._table)
         self._table.horizontalHeader().setStretchLastSection(False)
         self._table.horizontalHeader().setSectionResizeMode(
             _COL_MSG, QHeaderView.ResizeMode.Stretch
@@ -1402,6 +1405,7 @@ class MultiLogViewer(QWidget):
         scroll.setWidgetResizable(False)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        install_horizontal_wheel_scroll(scroll, smooth_item_scroll=False)
         scroll.setFixedHeight(32)
         scroll.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 

--- a/crush/viewers/protobuf_viewer.py
+++ b/crush/viewers/protobuf_viewer.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.tree_viewer import TreeViewer
 
 
@@ -226,6 +227,7 @@ class ProtobufTreeWidget(QWidget):
         self._tree.setModel(self._model)
         self._tree.setAlternatingRowColors(True)
         self._tree.setAnimated(True)
+        install_horizontal_wheel_scroll(self._tree)
         self._tree.header().setStretchLastSection(False)
         self._tree.setColumnWidth(0, 140)
         self._tree.setColumnWidth(1, 340)

--- a/crush/viewers/realm_viewer.py
+++ b/crush/viewers/realm_viewer.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import QEvent, Qt
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
     QLabel,
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.tree_viewer import TreeViewer
 from crush.viewers.hex_viewer import HexViewer
 from crush.viewers.table_viewer import BlobInspector, TableViewer, _cap_columns
@@ -87,10 +88,10 @@ class FreeDataViewer(QWidget):
         self._table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
         self._table.setSelectionMode(QTableView.SelectionMode.SingleSelection)
         self._table.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
+        install_horizontal_wheel_scroll(self._table)
         self._table.horizontalHeader().setStretchLastSection(True)
         self._table.resizeColumnsToContents()
         _cap_columns(self._table)
-        self._table.viewport().installEventFilter(self)
         self._table.selectionModel().currentRowChanged.connect(self._on_row_changed)
         self._table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._table.customContextMenuRequested.connect(self._on_context_menu)
@@ -119,14 +120,6 @@ class FreeDataViewer(QWidget):
         row = current.row()
         if 0 <= row < len(self._blocks):
             self._hex.set_data(self._blocks[row]["bytes"])
-
-    def eventFilter(self, watched, event) -> bool:
-        if event.type() == QEvent.Type.Wheel:
-            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
-                hbar = self._table.horizontalScrollBar()
-                hbar.setValue(hbar.value() - event.angleDelta().y() // 2)
-                return True
-        return super().eventFilter(watched, event)
 
     def _on_context_menu(self, pos) -> None:
         index = self._table.indexAt(pos)

--- a/crush/viewers/table_viewer.py
+++ b/crush/viewers/table_viewer.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from PySide6.QtCore import (
     QAbstractTableModel,
-    QEvent,
     QModelIndex,
     QObject,
     QRegularExpression,
@@ -67,6 +66,7 @@ from crush.core.work_priority import (
     foreground_io,
     release_foreground_io,
 )
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.blob_inspector import BlobInspector
 
 
@@ -689,7 +689,9 @@ class TableViewer(QWidget):
         self._table_view.horizontalHeader().customContextMenuRequested.connect(self._on_header_context_menu)
         self._table_view.verticalHeader().setDefaultSectionSize(22)
         self._table_view.doubleClicked.connect(self._on_table_double_clicked)
-        self._table_view.viewport().installEventFilter(self)
+        install_horizontal_wheel_scroll(
+            self._table_view, on_wheel=self._on_table_scroll_activity
+        )
         self._table_view.verticalScrollBar().valueChanged.connect(
             self._on_table_scroll_activity
         )
@@ -1839,15 +1841,6 @@ class TableViewer(QWidget):
                 self._cell_detail_view.setPlainText(preview)
         else:
             self._cell_detail_view.setPlainText(display_str)
-
-    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.Wheel:
-            self._on_table_scroll_activity()
-            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:  # type: ignore[union-attr]
-                hbar = self._table_view.horizontalScrollBar()
-                hbar.setValue(hbar.value() - event.angleDelta().y() // 2)  # type: ignore[union-attr]
-                return True
-        return super().eventFilter(watched, event)
 
     def _on_table_scroll_activity(self, _value: int = 0) -> None:
         if not self._table_interaction_active:

--- a/crush/viewers/text_viewer.py
+++ b/crush/viewers/text_viewer.py
@@ -31,6 +31,7 @@ from PySide6.QtWidgets import (
 
 from crush.core.encodings import detect_encoding as _detect_encoding
 from crush.core.formatters import pretty_json
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
 
 class _LineNumberArea(QWidget):
@@ -200,6 +201,7 @@ class TextView(QWidget):
         self._editor = _CodeEditor()
         self._editor.setReadOnly(True)
         self._editor.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        install_horizontal_wheel_scroll(self._editor, smooth_item_scroll=False)
 
         font = QFont("Courier New", 10)
         font.setStyleHint(QFont.StyleHint.Monospace)

--- a/crush/viewers/tree_viewer.py
+++ b/crush/viewers/tree_viewer.py
@@ -20,6 +20,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
+
 _USER_ROLE = Qt.ItemDataRole.UserRole
 
 
@@ -67,6 +69,7 @@ class TreeViewer(QWidget):
         self._tree.setModel(self._model)
         self._tree.setAlternatingRowColors(True)
         self._tree.setAnimated(True)
+        install_horizontal_wheel_scroll(self._tree)
         self._tree.header().setStretchLastSection(False)
         self._tree.setColumnWidth(0, 220)
         self._tree.setColumnWidth(1, 300)


### PR DESCRIPTION
some viewer areas were not side scrolling with shift+mouse wheel but some were. some worked in macOS but not in windows. some views such as sqlite table were scrolling based on columns.

fixes:
- set tables to pixel based scrolling
- build central function for event filtering
- 'install' function on all controls except format reference table

verified on macOS and windows, but not on linux