### PR TITLE
fix: extend "Open in New Window" to files inside archives (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Crush will be documented in this file.
 ### Bug Fixes
 
 - **SQLite temp companion files not deleted on close** — when a SQLite database with WAL or SHM companions was opened, `SQLiteParser` correctly extracted all three files (`-wal`, `-shm`) to the OS temp directory, but `TableViewer.closeEvent` only deleted the main `.db` file. The companion files are now also deleted on close.
+- **"Open in New Window" missing inside archives** — the context menu entry only appeared for files with a real path on disk, so a SQLite database or nested archive found inside an opened ZIP/TAR was stuck without it. The file is now extracted to a temp file and loaded into the new window regardless of source type; the extracted file's cleanup is now owned by the new window rather than the source window, so closing the archive window first no longer deletes the file out from under the still-open new window. If Integrity Mode is on, the original archive-relative path is hashed and logged before extraction, so the chain-of-custody log still reflects where the file actually came from. Re-addresses [#15](https://github.com/kalink0/crush-forensics/issues/15).
 
 ## v0.12.1 - 2026-06-22
 

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -64,6 +64,7 @@ The left panel shows the loaded archive or folder as a tree.
 - **Single-click** selects a file and updates the Properties panel
 - **Right-click** a file or folder for options:
   - **Open** — best viewer for the format
+  - **Open in New Window** — loads the file into a fresh Crush window without affecting the current session. Works for any file, including ones nested inside an already-open ZIP/TAR archive — the file is transparently extracted to a temp location for the new window
   - **Open in Hex** — force raw hex view
   - **Open as Plain Text** — force text view
   - **Open in Multi-Log Studio** — structured log viewer with level/time/text filtering and multi-source support

--- a/crush/ui/fs_panel.py
+++ b/crush/ui/fs_panel.py
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
 
 
 from crush.core.session import Session
-from crush.core.vfs import VFS, VFSNode, DirectoryVFS
+from crush.core.vfs import VFS, VFSNode
 from crush.core.magic import detect_fast_label
 from crush.core.work_priority import background_io
 from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
@@ -91,7 +91,7 @@ class FilesystemPanel(QWidget):
     export_logarchive_requested = Signal(object, object)  # (VFSNode, VFS)
     format_info_requested = Signal(object, object)  # (VFSNode, VFS)
     close_source_requested = Signal(object)  # (VFS)
-    open_in_new_window_requested = Signal(str)  # (path)
+    open_in_new_window_requested = Signal(object, object)  # (VFSNode, VFS)
     load_finished = Signal()
     background_status = Signal(str)
     _search_results_ready = Signal(object)  # internal: list of result dicts
@@ -430,7 +430,7 @@ class FilesystemPanel(QWidget):
         menu = QMenu(self)
         open_action = menu.addAction("Open")
         open_in_new_window_action = None
-        if not node.is_dir and isinstance(vfs, DirectoryVFS):
+        if not node.is_dir:
             open_in_new_window_action = menu.addAction("Open in New Window")
         open_hex_action = menu.addAction("Open in Hex")
         open_text_action = menu.addAction("Open as Plain Text")
@@ -478,7 +478,7 @@ class FilesystemPanel(QWidget):
         if action is None:
             return
         if action == open_in_new_window_action:
-            self.open_in_new_window_requested.emit(node.path)
+            self.open_in_new_window_requested.emit(node, vfs)
         elif action == open_action:
             self.open_requested.emit(node, vfs, "default")
         elif action == open_hex_action:

--- a/crush/ui/main_window.py
+++ b/crush/ui/main_window.py
@@ -655,11 +655,24 @@ class MainWindow(QMainWindow):
         window.move(target)
         window.show()
 
-    def _open_in_new_window(self, path: str) -> None:
+    def _open_in_new_window(self, node: VFSNode, vfs: VFS) -> None:
+        self._hash_node_if_integrity(node, vfs)
+        path = self._materialize_node_for_external(node, vfs)
+        if path is None:
+            QMessageBox.warning(
+                self, "Open in New Window", f"Unable to materialize {node.name!r} for a new window."
+            )
+            return
         window = MainWindow()
         window.resize(self.size())
         window.show()
-        window._load_source(path)
+        if not isinstance(vfs, DirectoryVFS):
+            # The temp file was materialized in this (source) window's
+            # tracking list; transfer ownership to the new window so its
+            # cleanup runs when that window closes, not this one.
+            self._external_temp_paths.remove(path)
+            window._external_temp_paths = [path]
+        window._load_source(str(path))
 
     @classmethod
     def _remove_window_reference(cls, destroyed: QObject | None = None) -> None:


### PR DESCRIPTION
The context menu entry only appeared for files with a real path on disk, so a SQLite database or nested archive found inside an opened ZIP/TAR had no way to open in a new window. The file is now extracted to a temp file regardless of source type, with ownership of that temp file transferred to the new window so closing the source (archive) window first no longer deletes it out from under the still-open new window. Integrity Mode now hashes the original archive-relative path before extraction, so the chain-of-custody log still reflects where the file actually came from. closes #15 