### PR TITLE
fix: offer "Open as Hex" fallback when a source fails to load (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Crush will be documented in this file.
 
 ## [Unreleased]
 
+### Improvements
+
+- **"Open as Hex" fallback on load error** — when a source fails to load (e.g. a corrupt or truncated ZIP), the error dialog now offers an "Open as Hex" button that opens the raw file bytes in the hex viewer instead of leaving the file completely inaccessible. Addresses [#31](https://github.com/kalink0/crush-forensics/issues/31).
+
 ### Bug Fixes
 
 - **SQLite temp companion files not deleted on close** — when a SQLite database with WAL or SHM companions was opened, `SQLiteParser` correctly extracted all three files (`-wal`, `-shm`) to the OS temp directory, but `TableViewer.closeEvent` only deleted the main `.db` file. The companion files are now also deleted on close.

--- a/crush/ui/main_window.py
+++ b/crush/ui/main_window.py
@@ -753,7 +753,32 @@ class MainWindow(QMainWindow):
             self._progress.close()
         self._status.showMessage(f"Error loading source: {message}")
         self._logger.error("Load error: %s", message)
-        QMessageBox.critical(self, "Load error", message)
+
+        path = getattr(self, "_loading_path", None)
+        offer_hex = bool(path) and Path(path).is_file()
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Critical)
+        box.setWindowTitle("Load error")
+        box.setText(message)
+        box.addButton(QMessageBox.StandardButton.Ok)
+        hex_button = (
+            box.addButton("Open as Hex", QMessageBox.ButtonRole.ActionRole) if offer_hex else None
+        )
+        box.exec()
+        if hex_button is not None and box.clickedButton() is hex_button:
+            self._open_failed_source_as_hex(path)
+
+    def _open_failed_source_as_hex(self, path: str) -> None:
+        try:
+            data = Path(path).read_bytes()
+        except Exception as exc:
+            QMessageBox.warning(self, "Open as Hex", f"Could not read {path!r}: {exc}")
+            return
+        from crush.viewers.hex_viewer import HexViewer
+        viewer = HexViewer(data, self)
+        idx = self._viewer_tabs.addTab(viewer, f"{Path(path).name} [Hex]")
+        self._viewer_tabs.setCurrentIndex(idx)
 
     def _on_tree_loaded(self) -> None:
         self._logger.debug("Tree load finished")


### PR DESCRIPTION
Loading a corrupt or truncated archive (or any other file) as a source only showed a bare error dialog with no way to inspect the file. The load-error dialog now adds an "Open as Hex" button (shown only when the failed path is an actual file) that reads the full raw bytes and opens them in the hex viewer, so the file stays inspectable instead of being a dead end.
closes #31 