### PR TITLE
fix: pin crypto build to working version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,14 +60,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyinstaller
-          python -m pip install .
+          python -m pip install --only-binary=cryptography -c release-constraints.txt .
 
       - name: Install Python deps (Windows)
         if: runner.os == 'Windows'
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyinstaller Pillow
-          python -m pip install .
+          python -m pip install --only-binary=cryptography -c release-constraints.txt .
           python -m pip install python-magic-bin
 
       - name: Download unifiedlog_iterator binary (Linux)

--- a/release-constraints.txt
+++ b/release-constraints.txt
@@ -1,0 +1,1 @@
+cryptography==48.0.1


### PR DESCRIPTION
pinned `cryptography` to `48.0.1` to fix release builds. for some reason `49` doesn't have the binary needed for the intel build so it built from source and caused the failure. `48` has the needed binaries. this builds and runs locally on my Intel Mac.

edit: I can also open and decrypt an iTunes backup with this built on Intel Mac 