### PR TITLE
fix: rename apple silicon artifact to use 'arm'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             echo "MACOS_UL_BINARY=unifiedlog_iterator-aarch64-apple-darwin" >> $GITHUB_ENV
-            echo "MACOS_ARTIFACT=crush-macos-${{ github.ref_name }}.zip" >> $GITHUB_ENV
+            echo "MACOS_ARTIFACT=crush-macos-arm-${{ github.ref_name }}.zip" >> $GITHUB_ENV
           else
             echo "MACOS_UL_BINARY=unifiedlog_iterator-x86_64-apple-darwin" >> $GITHUB_ENV
             echo "MACOS_ARTIFACT=crush-macos-intel-${{ github.ref_name }}.zip" >> $GITHUB_ENV


### PR DESCRIPTION
in light of the intel build failure, renaming the apple silicon / arm artifact zip to include `arm` in the name for clarity. I had initially downloaded the unlabeled zip thinking that you might have made a universal binary but the app wasn't the correct architecture. I hadn't yet seen your doc notes or the build failure log.