### PR TITLE
feat: PDF page rendering (pypdfium2) with encrypted-PDF support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Crush will be documented in this file.
 ### New Features
 
 - **Properties panel shows the original iTunes backup file ID** — the raw `fileID`-named path (e.g. `ab/ab54f7c9...e1`) is now shown alongside the resolved `domain/relativePath`, for files only. Addresses [#41](https://github.com/kalink0/crush-forensics/issues/41).
+- **PDF viewer renders pages, not just text** — double-clicking a PDF now shows a "Pages" tab with page-by-page rendering (via `pypdfium2`) and navigation/zoom, alongside the existing extracted-text "Text" tab. Password-protected PDFs are supported via **Open as → PDF (Encrypted)…**.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Supported viewers (more planned):
 - Media Viewer (audio/video)
 - Multi-Log Studio (multi-source log analysis with format auto-detection; Apple Unified Log / `.tracev3` / `.logarchive`, syslog, and more)
 - Protobuf Viewer (schema-less; optional schema decoding)
-- PDF text extraction (displays extracted text)
+- PDF Viewer (page-by-page rendering with zoom, plus extracted text; password-protected PDFs supported)
 - Realm Database Viewer (header, schema/class extraction, top-ref comparison, table/column data decoding)
 
 ## Documentation

--- a/crush/docs/format-support.md
+++ b/crush/docs/format-support.md
@@ -14,7 +14,7 @@ This page lists what Crush can parse and how each viewer behaves, plus the curre
 - Detects SQLite by magic bytes and loads tables and rows into the Table Viewer.
 - Copies companion `-wal` and `-shm` files if present.
 - The `-wal` companion is parsed directly, frame by frame, rather than only letting SQLite apply it: every frame is classified as **Active** (the current version of that page), **Superseded** (an older version of a page later overwritten in the same WAL — may still hold rows since edited or deleted), **Uncommitted** (part of a transaction that never committed, e.g. a device seized mid-write), or **WAL slack** (salt-mismatch frames left over from a previous WAL reuse cycle, i.e. stale data still physically present in the file). Pages are attributed back to their table by walking the B-tree from each table's root page in `sqlite_master`, across both the WAL frames and the main file. A **WAL Frames** tab lists every frame with its frame number, page, transaction, status, and attributed table; double-click a frame to open its raw page bytes in the Hex Viewer. Per table, a **Show WAL history** toggle re-parses the table's non-Active frames as table-leaf pages and injects their rows straight into the row grid alongside the current data, colour-coded by status and labelled with the source frame (e.g. `WAL Superseded (frame 12)`) — these WAL-sourced rows are additional to, and not subject to, the 10,000-row display cap below.
-- SQLCipher-encrypted databases are supported when the password or key is known — right-click the file → **Open as** → **SQLite DB (SQLCipher)…**; a wrong password/key re-prompts instead of failing silently. This opens the real SQLCipher engine (the `sqlcipher3` package, not a custom decryption), so page and WAL-frame decryption/checkpointing are handled natively rather than reimplemented — including data that only ever made it into a `-wal` companion, never checkpointed into the main file (a device seized mid-session, before the app itself closed its DB connection). By default, opening tries the linked library's current default cipher settings first, then each legacy `cipher_compatibility` preset (SQLCipher 4 down to 1) in turn — each attempt is a real, cryptographically-verified pass/fail via the engine's own per-page HMAC check, not a guess. As with encrypted `.realm` files, a normal double-click open never auto-prompts, since ciphertext (including what would be the plaintext magic header) can't be told apart from corrupt/other binary data.
+- SQLCipher-encrypted databases are supported when the password or key is known — right-click the file → **Open as** → **SQLite DB (Encrypted)…**; a wrong password/key re-prompts instead of failing silently. This opens the real SQLCipher engine (the `sqlcipher3` package, not a custom decryption), so page and WAL-frame decryption/checkpointing are handled natively rather than reimplemented — including data that only ever made it into a `-wal` companion, never checkpointed into the main file (a device seized mid-session, before the app itself closed its DB connection). By default, opening tries the linked library's current default cipher settings first, then each legacy `cipher_compatibility` preset (SQLCipher 4 down to 1) in turn — each attempt is a real, cryptographically-verified pass/fail via the engine's own per-page HMAC check, not a guess. As with encrypted `.realm` files, a normal double-click open never auto-prompts, since ciphertext (including what would be the plaintext magic header) can't be told apart from corrupt/other binary data.
 - The credentials dialog has a **Raw key** option for a key that isn't a passphrase — SQLCipher's own recommended approach when the key is "managed externally" (e.g. an Android Keystore-derived key), rather than typed by a user. Raw key applies independently of whether Advanced parameters are also set, since page size and HMAC algorithm still matter even without a passphrase KDF.
 - An **Advanced** section exposes explicit cipher parameters (page size, KDF iterations, KDF/HMAC digest, plaintext header size) for apps whose settings don't match any standard `cipher_compatibility` preset — notably Signal and its forks (Session, Molly), which set `kdf_iter = 1` since their key already comes from the platform keystore at full entropy, making the passphrase-stretching KDF pointless overhead. When Advanced is used, those exact parameters are applied in a single attempt instead of the auto-try.
 
@@ -122,11 +122,12 @@ Limitations
 - Playback depends on system multimedia codecs.
 
 ### PDF
-- Extracts text using `pypdf` and shows it in the Text Viewer.
+- Renders pages as images (via `pypdfium2`) in a **Pages** tab, with prev/next navigation and zoom, alongside a **Text** tab with the text extracted via `pypdf`.
+- Password-protected PDFs: right-click → **Open as** → **PDF (Encrypted)…**; a wrong password re-prompts instead of failing silently. A normal double-click never auto-prompts, since an encrypted PDF's content can't be told apart from a corrupt one from the header alone.
 
 Limitations
-- Without `pypdf` installed, PDFs open in Hex Viewer with a note.
-- Some PDFs have no extractable text (scanned or protected files).
+- Without `pypdf`/`pypdfium2` installed, PDFs open in Hex Viewer with a note.
+- Some PDFs have no extractable text (scanned or protected files) — the Pages tab still renders normally in that case.
 
 ### Log Files (Explicit Only)
 - Open via context menu: **Open in Multi-Log Studio**.
@@ -240,5 +241,4 @@ Limitations
 ## Known Gaps (Planned)
 
 - Extended EXIF/metadata viewer
-- PDF page rendering (not just text extraction)
 - Type/extension filters in the filesystem panel

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -72,6 +72,8 @@ The left panel shows the loaded archive or folder as a tree.
     - **Text** — force text view
     - **Protobuf** — schema-less Protobuf decode (optionally load a `.proto` schema)
     - **Realm DB (Encrypted)…** — decrypt and open a Realm database given its 64-byte encryption key (as a hex string). This is the only way to open an encrypted `.realm` file — a normal double-click never prompts for a key, since a header that fails to decode is equally consistent with "encrypted" and "corrupt/non-standard" and can't be told apart from content alone
+    - **SQLite DB (Encrypted)…** — open a SQLCipher-encrypted SQLite database given its password or raw key, with optional advanced cipher parameters. Same no-auto-prompt rule as Realm above
+    - **PDF (Encrypted)…** — open a password-protected PDF; a wrong password re-prompts instead of failing silently. Same no-auto-prompt rule as Realm above
   - **Open in Multi-Log Studio** — structured log viewer with level/time/text filtering and multi-source support
   - **Add to Multi-Log Studio** — adds the file as an additional source to the currently open studio tab
   - **Open External (Default)** — hand off to the OS default application
@@ -279,7 +281,7 @@ Parses XML into a collapsible tree. Android `<map>`-style preference files are f
 
 ### PDF Viewer
 
-Extracts and displays the text content of PDF files in the Text Viewer. Scanned or protected PDFs with no extractable text show a notice.
+Two tabs: **Pages** renders each page as an image, with prev/next navigation and a zoom slider, so layout, images, and form fields are visible — not just extractable text. **Text** shows the text extracted from the PDF, same as before. Password-protected PDFs open via right-click → **Open as** → **PDF (Encrypted)…**.
 
 ### LevelDB Viewer
 

--- a/crush/parsers/base.py
+++ b/crush/parsers/base.py
@@ -20,6 +20,7 @@ ViewerType = Literal[
     "protobuf",
     "realm",
     "leveldb",
+    "pdf",
 ]
 
 

--- a/crush/parsers/pdf_parser.py
+++ b/crush/parsers/pdf_parser.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 - now Marco Neumann (kalink0)
-"""PDF parser — extracts text from PDF files using pypdf."""
+"""PDF parser — renders pages (via pypdfium2) and extracts text (via pypdf)."""
 from __future__ import annotations
 
 import logging
 from io import BytesIO
 from typing import Any
 
+from crush.core.passwords import WrongPasswordError
 from crush.core.vfs import VFS, VFSNode
 from crush.parsers.base import AbstractParser, ParseResult
 
@@ -16,11 +17,12 @@ _logger = logging.getLogger(__name__)
 class PDFParser(AbstractParser):
     SUPPORTED_EXTENSIONS = [".pdf"]
     DISPLAY_NAME = "PDF document"
+    SUPPORTS_PASSWORD = True
 
     def can_parse(self, path: str, peek_bytes: bytes) -> bool:
         return peek_bytes[:4] == b"%PDF"
 
-    def parse(self, node: VFSNode, vfs: VFS) -> ParseResult:
+    def parse(self, node: VFSNode, vfs: VFS, password: str | None = None) -> ParseResult:
         raw = vfs.read(node)
         try:
             import pypdf
@@ -36,6 +38,27 @@ class PDFParser(AbstractParser):
             )
         try:
             reader = pypdf.PdfReader(BytesIO(raw), strict=False)
+            if reader.is_encrypted:
+                if password is None:
+                    # A plain double-click never auto-prompts -- same as
+                    # Realm/SQLCipher -- but unlike those, a PDF's %PDF
+                    # header/xref/trailer structure is never itself
+                    # encrypted (only string/stream content is), so we can
+                    # tell "this is a PDF, and it's encrypted" for certain
+                    # here and say so directly, rather than surfacing pypdf's
+                    # raw FileNotDecryptedError text as an incidental hint.
+                    return ParseResult(
+                        viewer_type="hex",
+                        data=raw,
+                        metadata={
+                            "Format": "PDF",
+                            "File size": f"{node.size:,} B",
+                            "Possibly Encrypted": "Try Open as → PDF (Encrypted)…",
+                        },
+                    )
+                result = reader.decrypt(password)
+                if not result:
+                    raise WrongPasswordError(f"Wrong password for encrypted PDF: {node.path}")
             pages: list[str] = []
             for i, page in enumerate(reader.pages, 1):
                 try:
@@ -67,11 +90,14 @@ class PDFParser(AbstractParser):
                         meta[label] = str(val)[:200]
 
             return ParseResult(
-                viewer_type="text",
-                data=full_text,
+                viewer_type="pdf",
+                data=raw,
                 metadata=meta,
                 text_index=full_text[:4000],
+                viewer_hints={"extracted_text": full_text, "password": password},
             )
+        except WrongPasswordError:
+            raise
         except Exception as exc:
             _logger.warning("PDF parse error for %s: %s", node.path, exc)
             return ParseResult(

--- a/crush/parsers/realm_parser.py
+++ b/crush/parsers/realm_parser.py
@@ -2164,7 +2164,8 @@ class RealmParser(AbstractParser):
             if schema:
                 meta["Tables found"] = str(len(schema))
         else:
-            meta["Header"] = "Not detected (possibly encrypted or non-standard)"
+            meta["Header"] = "Not detected (corrupt or non-standard)"
+            meta["Possibly Encrypted"] = "Try Open as → Realm DB (Encrypted)…"
 
         text_parts: list[str] = []
         for t in tables:

--- a/crush/parsers/sqlite_parser.py
+++ b/crush/parsers/sqlite_parser.py
@@ -229,7 +229,7 @@ class SQLiteParser(AbstractParser):
                         _logger.debug("Could not load filesystem companion %s: %s", fs_companion.name, exc)
 
         if password is not None:
-            # Explicit "Open as -> SQLite DB (SQLCipher)…" path only -- the
+            # Explicit "Open as -> SQLite DB (Encrypted)…" path only -- the
             # normal open flow never passes a password, since an encrypted
             # file's content (including what would be the plaintext magic
             # header) is ciphertext, indistinguishable from corrupt/other

--- a/crush/tests/test_parsers.py
+++ b/crush/tests/test_parsers.py
@@ -80,7 +80,7 @@ def test_sqlcipher_can_parse_returns_false_without_a_key(tmp_path: Path) -> None
     would be the SQLite magic header on a plaintext file -- is ciphertext,
     indistinguishable from corrupt/other binary data. can_parse() must stay
     False so a normal double-click open never auto-prompts for a password;
-    only the explicit "Open as -> SQLite DB (SQLCipher)…" action tries."""
+    only the explicit "Open as -> SQLite DB (Encrypted)…" action tries."""
     db_path = tmp_path / "encrypted.db"
     _make_sqlcipher(db_path, "hunter2")
 

--- a/crush/ui/about_dialog.py
+++ b/crush/ui/about_dialog.py
@@ -108,6 +108,12 @@ your support makes this project possible.</p>
     <td><a href="https://pypdf.readthedocs.io/">pypdf</a></td>
   </tr>
   <tr class="alt">
+    <td><b>pypdfium2</b></td>
+    <td>PDF page rendering (PDF viewer)</td>
+    <td class="lic">Apache 2.0 / BSD 3-Clause</td>
+    <td><a href="https://pypdfium2.readthedocs.io/">pypdfium2</a></td>
+  </tr>
+  <tr>
     <td><b>grpcio-tools</b></td>
     <td>Protobuf / .proto schema compilation (optional, used by Protobuf viewer)</td>
     <td class="lic">Apache 2.0</td>

--- a/crush/ui/fs_panel.py
+++ b/crush/ui/fs_panel.py
@@ -439,10 +439,12 @@ class FilesystemPanel(QWidget):
         open_proto_action = open_as_menu.addAction("Protobuf")
         open_realm_encrypted_action = None
         open_sqlcipher_action = None
+        open_pdf_encrypted_action = None
         if not node.is_dir:
             open_as_menu.addSeparator()
             open_realm_encrypted_action = open_as_menu.addAction("Realm DB (Encrypted)…")
-            open_sqlcipher_action = open_as_menu.addAction("SQLite DB (SQLCipher)…")
+            open_sqlcipher_action = open_as_menu.addAction("SQLite DB (Encrypted)…")
+            open_pdf_encrypted_action = open_as_menu.addAction("PDF (Encrypted)…")
         open_logs_folder_action = None
         open_multi_log_action   = None
         add_multi_log_action    = None
@@ -513,6 +515,8 @@ class FilesystemPanel(QWidget):
             self.open_requested.emit(node, vfs, "realm_encrypted")
         elif action == open_sqlcipher_action:
             self.open_requested.emit(node, vfs, "sqlcipher")
+        elif action == open_pdf_encrypted_action:
+            self.open_requested.emit(node, vfs, "pdf_encrypted")
         elif action == open_external_default:
             self.open_external_requested.emit(node, vfs, "default")
         elif action == open_external_choose:

--- a/crush/ui/main_window.py
+++ b/crush/ui/main_window.py
@@ -1045,9 +1045,19 @@ class MainWindow(QMainWindow):
             result = self._enrich_with_format_info(parser, node, vfs, result)
             self._show_result(node, result, vfs)
             self._props_panel.update_properties(node, result.metadata, vfs)
-            self._status.showMessage(
-                f"{node.path}  [{parser.DISPLAY_NAME}]"
-            )
+            possibly_encrypted = result.metadata.get("Possibly Encrypted")
+            if possibly_encrypted:
+                # A normal double-click never auto-prompts for a password (see
+                # pdf_parser.py / realm_parser.py), but that shouldn't mean the
+                # hint is invisible unless the user happens to be looking at
+                # the Properties panel -- surface it in the status bar too.
+                self._status.showMessage(
+                    f"{node.path}  [{parser.DISPLAY_NAME} — {possibly_encrypted}]"
+                )
+            else:
+                self._status.showMessage(
+                    f"{node.path}  [{parser.DISPLAY_NAME}]"
+                )
         except Exception as exc:
             self._status.showMessage(f"Parse error: {exc}")
             QMessageBox.warning(self, "Parse error", str(exc))
@@ -1148,6 +1158,10 @@ class MainWindow(QMainWindow):
             self._hash_node_if_integrity(node, vfs)
             self._open_encrypted_sqlite(node, vfs)
             return
+        if mode == "pdf_encrypted":
+            self._hash_node_if_integrity(node, vfs)
+            self._open_encrypted_pdf(node, vfs)
+            return
         self._open_node(node, vfs)
 
     def _open_encrypted_sqlite(self, node: VFSNode, vfs: VFS, was_wrong: bool = False) -> None:
@@ -1208,6 +1222,37 @@ class MainWindow(QMainWindow):
         except Exception as exc:
             self._status.showMessage(f"Realm decrypt error: {exc}")
             QMessageBox.warning(self, "Realm decrypt error", str(exc))
+            return
+
+        result = self._enrich_with_format_info(parser, node, vfs, result)
+        self._show_result(node, result, vfs)
+        self._props_panel.update_properties(node, result.metadata, vfs)
+        self._status.showMessage(f"{node.path}  [{parser.DISPLAY_NAME} — decrypted]")
+
+    def _open_encrypted_pdf(self, node: VFSNode, vfs: VFS, was_wrong: bool = False) -> None:
+        from crush.core.passwords import WrongPasswordError
+        from crush.parsers.pdf_parser import PDFParser
+
+        title = "Incorrect Password" if was_wrong else "PDF Password"
+        prompt = (
+            "Incorrect password. Please try again:"
+            if was_wrong
+            else "Enter the PDF's password:"
+        )
+        password, ok = QInputDialog.getText(self, title, prompt, QLineEdit.EchoMode.Password)
+        if not ok or not password:
+            self._status.showMessage("Load cancelled: password required")
+            return
+
+        parser = PDFParser()
+        try:
+            result = parser.parse(node, vfs, password=password)
+        except WrongPasswordError:
+            self._open_encrypted_pdf(node, vfs, was_wrong=True)
+            return
+        except Exception as exc:
+            self._status.showMessage(f"PDF decrypt error: {exc}")
+            QMessageBox.warning(self, "PDF decrypt error", str(exc))
             return
 
         result = self._enrich_with_format_info(parser, node, vfs, result)
@@ -1409,6 +1454,27 @@ class MainWindow(QMainWindow):
             metadata["Size"] = _format_size(node.size)
         self._props_panel.update_properties(node, metadata, vfs)
 
+    def _wrap_with_encryption_banner(self, view: QWidget, hint: str) -> QWidget:
+        """Prepend a prominent banner above *view* -- used when a parser's
+        metadata carries "Possibly Encrypted" (see pdf_parser.py /
+        realm_parser.py). The Properties panel already lists this metadata
+        too, but that's easy to miss; this puts it directly in the tab
+        content, impossible to miss, without popping up an interrupting
+        dialog on every double-click of an encrypted file."""
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        banner = QLabel(f"\U0001F512 This file appears to be encrypted. {hint}")
+        banner.setWordWrap(True)
+        banner.setStyleSheet(
+            "color: white; background-color: #c87000; font-weight: bold;"
+            " padding: 6px 10px;"
+        )
+        layout.addWidget(banner)
+        layout.addWidget(view)
+        return container
+
     def _show_result(self, node: VFSNode, result: ParseResult, vfs: VFS) -> None:
         from crush.ui.viewer_factory import make_viewer
         base_view = make_viewer(result, node, vfs, self)
@@ -1416,6 +1482,9 @@ class MainWindow(QMainWindow):
             base_view.open_bytes_requested.connect(self._open_bytes_as_artifact)
         if hasattr(base_view, "open_table_requested"):
             base_view.open_table_requested.connect(self._open_table_as_tab)
+        possibly_encrypted = result.metadata.get("Possibly Encrypted")
+        if possibly_encrypted:
+            base_view = self._wrap_with_encryption_banner(base_view, possibly_encrypted)
         widget: QWidget = base_view
         if self._always_hex:
             hex_bytes = self._read_hex_bytes(vfs, node)

--- a/crush/viewers/__init__.py
+++ b/crush/viewers/__init__.py
@@ -36,5 +36,11 @@ def _register_builtin_viewers() -> None:
     except ImportError:
         pass
 
+    try:
+        from crush.viewers.pdf_viewer import PDFViewer
+        ViewerRegistry.register("pdf", lambda r, n, v, p: PDFViewer(r.data, p, **r.viewer_hints))
+    except ImportError:
+        pass
+
 
 _register_builtin_viewers()

--- a/crush/viewers/pdf_viewer.py
+++ b/crush/viewers/pdf_viewer.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""PDF viewer — rendered pages (pypdfium2) alongside the extracted text."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSlider,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
+from crush.viewers.text_viewer import TextView
+
+# ~144 DPI (PDF page units are 72/inch) -- sharp enough for on-screen
+# reading without rendering every page at a wasteful resolution.
+_RENDER_SCALE = 2.0
+
+
+def _pil_to_pixmap(img: object) -> QPixmap:
+    """Same raw-pixel-transfer approach as image_viewer.py's _pillow_decode."""
+    rgba = img.convert("RGBA")  # type: ignore[attr-defined]
+    w, h = rgba.size
+    raw = rgba.tobytes("raw", "RGBA")
+    qimg = QImage(raw, w, h, w * 4, QImage.Format.Format_RGBA8888)
+    return QPixmap.fromImage(qimg)
+
+
+class _PdfPagesView(QWidget):
+    """Page-by-page rendered view with prev/next navigation and zoom.
+
+    Renders lazily, one page at a time, and caches only the current page's
+    pixmap -- a forensic PDF can run into hundreds of pages, so eagerly
+    rendering the whole document up front is out of the question.
+    """
+
+    def __init__(
+        self, data: bytes, password: str | None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._page = 0
+        self._scale = 1.0
+        self._page_pixmap: QPixmap | None = None
+        self._page_pixmap_index = -1
+        self._doc: object | None = None
+        self._page_count = 0
+        self._build_ui()
+        self._open(data, password)
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        nav_row = QHBoxLayout()
+        nav_row.setSpacing(8)
+        self._prev_btn = QPushButton("◀ Prev")
+        self._prev_btn.clicked.connect(self._prev_page)
+        nav_row.addWidget(self._prev_btn)
+        self._page_label = QLabel("")
+        nav_row.addWidget(self._page_label)
+        self._next_btn = QPushButton("Next ▶")
+        self._next_btn.clicked.connect(self._next_page)
+        nav_row.addWidget(self._next_btn)
+        nav_row.addStretch(1)
+        layout.addLayout(nav_row)
+
+        zoom_row = QHBoxLayout()
+        zoom_row.setSpacing(8)
+        zoom_out_btn = QPushButton("-")
+        zoom_out_btn.setFixedWidth(28)
+        zoom_out_btn.clicked.connect(lambda: self._zoom_to(self._scale / 1.25))
+        zoom_row.addWidget(zoom_out_btn)
+        self._zoom_slider = QSlider(Qt.Orientation.Horizontal)
+        self._zoom_slider.setRange(10, 400)
+        self._zoom_slider.setValue(100)
+        self._zoom_slider.setFixedWidth(140)
+        self._zoom_slider.valueChanged.connect(lambda v: self._zoom_to(v / 100.0))
+        zoom_row.addWidget(self._zoom_slider)
+        zoom_in_btn = QPushButton("+")
+        zoom_in_btn.setFixedWidth(28)
+        zoom_in_btn.clicked.connect(lambda: self._zoom_to(self._scale * 1.25))
+        zoom_row.addWidget(zoom_in_btn)
+        self._zoom_label = QLabel("100%")
+        zoom_row.addWidget(self._zoom_label)
+        zoom_row.addStretch(1)
+        layout.addLayout(zoom_row)
+
+        self._scroll = QScrollArea()
+        self._scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._scroll.setWidgetResizable(False)
+        install_horizontal_wheel_scroll(self._scroll, smooth_item_scroll=False)
+        self._page_image_label = QLabel()
+        self._page_image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._scroll.setWidget(self._page_image_label)
+        layout.addWidget(self._scroll)
+
+    def _open(self, data: bytes, password: str | None) -> None:
+        try:
+            import pypdfium2 as pdfium
+
+            self._doc = pdfium.PdfDocument(data, password=password)
+            self._page_count = len(self._doc)  # type: ignore[arg-type]
+        except Exception as exc:
+            self._page_image_label.setText(f"Unable to render PDF: {exc}")
+            self._prev_btn.setEnabled(False)
+            self._next_btn.setEnabled(False)
+            return
+        self._load_page()
+
+    def _render_current_page(self) -> QPixmap | None:
+        if self._doc is None or self._page_count == 0:
+            return None
+        if self._page_pixmap is not None and self._page_pixmap_index == self._page:
+            return self._page_pixmap
+        page = self._doc[self._page]  # type: ignore[index]
+        bitmap = page.render(scale=_RENDER_SCALE)
+        pixmap = _pil_to_pixmap(bitmap.to_pil())
+        self._page_pixmap = pixmap
+        self._page_pixmap_index = self._page
+        return pixmap
+
+    def _load_page(self) -> None:
+        pixmap = self._render_current_page()
+        if pixmap is None:
+            return
+        self._page_label.setText(f"Page {self._page + 1} / {self._page_count}")
+        self._prev_btn.setEnabled(self._page > 0)
+        self._next_btn.setEnabled(self._page < self._page_count - 1)
+        self._apply_scale(pixmap)
+
+    def _apply_scale(self, pixmap: QPixmap) -> None:
+        scaled = pixmap.scaled(
+            int(pixmap.width() * self._scale),
+            int(pixmap.height() * self._scale),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        self._page_image_label.setPixmap(scaled)
+        self._page_image_label.resize(scaled.size())
+
+    def _prev_page(self) -> None:
+        if self._page > 0:
+            self._page -= 1
+            self._load_page()
+
+    def _next_page(self) -> None:
+        if self._page < self._page_count - 1:
+            self._page += 1
+            self._load_page()
+
+    def _zoom_to(self, scale: float) -> None:
+        scale = max(0.1, min(scale, 4.0))
+        self._scale = scale
+        pixmap = self._render_current_page()
+        if pixmap is not None:
+            self._apply_scale(pixmap)
+        self._zoom_label.setText(f"{int(scale * 100)}%")
+        self._zoom_slider.blockSignals(True)
+        self._zoom_slider.setValue(int(scale * 100))
+        self._zoom_slider.blockSignals(False)
+
+
+class PDFViewer(QWidget):
+    """Tabbed PDF viewer: rendered pages plus the parser's extracted text."""
+
+    def __init__(
+        self,
+        data: bytes,
+        parent: QWidget | None = None,
+        extracted_text: str = "",
+        password: str | None = None,
+    ) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        tabs = QTabWidget()
+        tabs.addTab(_PdfPagesView(data, password, self), "Pages")
+        tabs.addTab(TextView(extracted_text, self), "Text")
+        layout.addWidget(tabs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-magic>=0.4.27",
     "filetype>=1.2.0",
     "pypdf>=4.0",
+    "pypdfium2>=4.0",
     "protobuf>=4.25",
     "grpcio-tools>=1.62",
     "Pillow>=10.0",


### PR DESCRIPTION
- "Pages" tab renders each page as an image with navigation/zoom, alongside the existing extracted-text "Text" tab.
- "Open as -> PDF (Encrypted)..." prompts for a password, same flow   as Realm/SQLCipher. Since a PDF's encryption is detected with   certainty (unlike Realm's ambiguous "corrupt or encrypted"), a   double-click on one now shows a clear in-tab banner and status-bar  hint instead of silently falling back to hex -- realm_parser.py adopts the same "Possibly Encrypted" metadata convention.