### PR TITLE
feat: PDF metadata extras, attachments, and revision-history diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to Crush will be documented in this file.
 ### New Features
 
 - **Properties panel shows the original iTunes backup file ID** — the raw `fileID`-named path (e.g. `ab/ab54f7c9...e1`) is now shown alongside the resolved `domain/relativePath`, for files only. Addresses [#41](https://github.com/kalink0/crush-forensics/issues/41).
-- **PDF viewer renders pages, not just text** — double-clicking a PDF now shows a "Pages" tab with page-by-page rendering (via `pypdfium2`) and navigation/zoom, alongside the existing extracted-text "Text" tab. Password-protected PDFs are supported via **Open as → PDF (Encrypted)…**.
+- **PDF viewer renders pages, not just text** — double-clicking a PDF now shows a "Pages" tab with page-by-page rendering (via `pypdfium2`) and navigation/zoom (also via Ctrl+scroll wheel, same as the Image viewer), alongside the existing extracted-text "Text" tab. Password-protected PDFs are supported via **Open as → PDF (Encrypted)…**.
+- **PDF: extended metadata, attachments, and revision history** — Properties panel gains PDF version, XMP metadata, and always-shown JavaScript/Signatures/Attachments/Revisions fields; embedded files get their own **Attachments** tab. PDFs saved multiple times get a **History** tab exposing every revision (including content/JS/attachments since removed from the current one), with **Text Diff** and **Visual Diff** (pixel-level page comparison) between any two revisions.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Supported viewers (more planned):
 - LevelDB Viewer (Chrome LevelDB / Android app databases)
 - Image Viewer
 - Media Viewer (audio/video)
-- Multi-Log Studio (multi-source log analysis with format auto-detection; Apple Unified Log / `.tracev3` / `.logarchive`, syslog, and more)
+- Multi-Log Studio (multi-source log analysis, format auto-detection)
 - Protobuf Viewer (schema-less; optional schema decoding)
-- PDF Viewer (page-by-page rendering with zoom, plus extracted text; password-protected PDFs supported)
-- Realm Database Viewer (header, schema/class extraction, top-ref comparison, table/column data decoding)
+- PDF Viewer (page rendering, text extraction, revision history)
+- Realm Database Viewer (schema and table decoding)
 
 ## Documentation
 

--- a/crush/docs/format-support.md
+++ b/crush/docs/format-support.md
@@ -122,12 +122,18 @@ Limitations
 - Playback depends on system multimedia codecs.
 
 ### PDF
-- Renders pages as images (via `pypdfium2`) in a **Pages** tab, with prev/next navigation and zoom, alongside a **Text** tab with the text extracted via `pypdf`.
+- Renders pages as images (via `pypdfium2`) in a **Pages** tab, with prev/next navigation and zoom (also Ctrl+scroll wheel), alongside a **Text** tab with the text extracted via `pypdf`.
 - Password-protected PDFs: right-click → **Open as** → **PDF (Encrypted)…**; a wrong password re-prompts instead of failing silently. A normal double-click never auto-prompts, since an encrypted PDF's content can't be told apart from a corrupt one from the header alone.
+- Properties panel: PDF version, `/Info` fields, and separately XMP metadata (a mismatch between the two is itself a forensic signal). JavaScript presence (`/Names/JavaScript`, `/OpenAction`), signature form fields (`/AcroForm` `/FT /Sig`), and attachment count are always shown, even when none are found, so it's clear these were actually checked.
+- Embedded files get an **Attachments** tab — open one as a new tab (routed through the normal parser pipeline) or export to disk.
+- **Revision history**: PDFs saved multiple times without a full rewrite (incremental updates, chained via each trailer's `/Prev` offset) get a **History** tab exposing every revision, including content, JavaScript, or attachments only present in an earlier revision and since removed from the current one. Sub-tabs: **Browse** (one revision at a time, full Pages/Text/Attachments; revisions with JavaScript/signatures/attachments are flagged with ⚠), **Text Diff** (line-level diff between any two revisions), and **Visual Diff** (pixel-level page comparison — catches a redaction box drawn *over* text, which a text diff can't see since the underlying content stream is untouched).
 
 Limitations
 - Without `pypdf`/`pypdfium2` installed, PDFs open in Hex Viewer with a note.
 - Some PDFs have no extractable text (scanned or protected files) — the Pages tab still renders normally in that case.
+- JavaScript detection only checks the two standard document-level locations, not every annotation/form-field's own `/AA` actions. Signature-field detection only checks top-level `/AcroForm` fields, not fields nested inside a `/Kids` hierarchy.
+- Revision detection was validated against classic cross-reference tables; PDF 1.5+ cross-reference *streams* use the same `/Prev` mechanism through `pypdf`'s public API and aren't expected to need special handling, but weren't separately tested against a real-world sample.
+- Visual Diff doesn't diff pages whose size differs between the two selected revisions (shows the newer one only, to avoid a misleading resize).
 
 ### Log Files (Explicit Only)
 - Open via context menu: **Open in Multi-Log Studio**.

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -281,7 +281,17 @@ Parses XML into a collapsible tree. Android `<map>`-style preference files are f
 
 ### PDF Viewer
 
-Two tabs: **Pages** renders each page as an image, with prev/next navigation and a zoom slider, so layout, images, and form fields are visible — not just extractable text. **Text** shows the text extracted from the PDF, same as before. Password-protected PDFs open via right-click → **Open as** → **PDF (Encrypted)…**.
+**Pages** renders each page as an image, with prev/next navigation and a zoom slider (also Ctrl+scroll wheel), so layout, images, and form fields are visible — not just extractable text. **Text** shows the text extracted from the PDF. Password-protected PDFs open via right-click → **Open as** → **PDF (Encrypted)…**.
+
+The Properties panel additionally shows the PDF version, XMP metadata, and always-visible JavaScript/Signatures/Attachments/Revisions fields (shown as "not present"/"none"/"0" rather than omitted, so it's clear these were actually checked, not skipped).
+
+If the PDF has embedded files, an **Attachments** tab lists them — double-click (or right-click → **Open as New Tab**) to open one through the normal viewer pipeline, or **Export…** to save it to disk.
+
+If the PDF was saved more than once without a full rewrite (an "incremental update" — very common, since most PDF editors default to this), a **History** tab appears with one entry per revision, oldest to newest:
+
+- **Browse** — full Pages/Text/Attachments for a single revision at a time. A revision containing JavaScript, a signature field, or an attachment is marked with a ⚠ on its selector button, so you don't have to click into every revision to spot one that matters.
+- **Text Diff** — a line-level diff (like `git diff`) between any two revisions, defaulting to the last two.
+- **Visual Diff** — a pixel-level comparison of the same page across two revisions, with differing regions highlighted in red. Catches changes a text diff can't see, e.g. a black box drawn *over* text without touching the underlying content stream (the text is still there, just visually covered) — the classic "redaction that isn't."
 
 ### LevelDB Viewer
 

--- a/crush/parsers/pdf_parser.py
+++ b/crush/parsers/pdf_parser.py
@@ -5,13 +5,27 @@ from __future__ import annotations
 
 import logging
 from io import BytesIO
-from typing import Any
+from typing import Any, NamedTuple
 
 from crush.core.passwords import WrongPasswordError
 from crush.core.vfs import VFS, VFSNode
 from crush.parsers.base import AbstractParser, ParseResult
 
 _logger = logging.getLogger(__name__)
+
+
+class PdfRevision(NamedTuple):
+    """One entry in a PDF's incremental-update chain (oldest to newest,
+    see PDFParser._split_revisions). Carries the same signals computed for
+    the current/final document -- JavaScript, signatures, and attachments
+    can each be added in one revision and removed in a later one, so
+    checking only the final state can miss them (relevant for IR, not
+    just "what does this PDF look like now")."""
+    data: bytes
+    text: str
+    has_javascript: bool
+    signatures: str
+    attachments: list[tuple[str, bytes]]
 
 
 class PDFParser(AbstractParser):
@@ -38,6 +52,9 @@ class PDFParser(AbstractParser):
             )
         try:
             reader = pypdf.PdfReader(BytesIO(raw), strict=False)
+            pdf_version = reader.pdf_header or ""  # e.g. "%PDF-1.7" -- always
+            # readable even when encrypted, since only string/stream content
+            # is ciphertext, never the header/xref/trailer structure.
             if reader.is_encrypted:
                 if password is None:
                     # A plain double-click never auto-prompts -- same as
@@ -52,6 +69,7 @@ class PDFParser(AbstractParser):
                         data=raw,
                         metadata={
                             "Format": "PDF",
+                            "PDF Version": pdf_version,
                             "File size": f"{node.size:,} B",
                             "Possibly Encrypted": "Try Open as → PDF (Encrypted)…",
                         },
@@ -59,22 +77,16 @@ class PDFParser(AbstractParser):
                 result = reader.decrypt(password)
                 if not result:
                     raise WrongPasswordError(f"Wrong password for encrypted PDF: {node.path}")
-            pages: list[str] = []
-            for i, page in enumerate(reader.pages, 1):
-                try:
-                    text = page.extract_text() or ""
-                except Exception:
-                    text = ""
-                if text.strip():
-                    pages.append(f"--- Page {i} ---\n{text.strip()}")
-
-            full_text = "\n\n".join(pages) if pages else "[No extractable text in this PDF]"
+            full_text = self._extract_text(reader)
 
             meta: dict[str, Any] = {
                 "Format": "PDF",
+                "PDF Version": pdf_version,
                 "Pages": str(len(reader.pages)),
                 "File size": f"{node.size:,} B",
             }
+            if password is not None:
+                meta["Encrypted"] = "Yes (password supplied)"
             info = reader.metadata
             if info:
                 for attr, label in (
@@ -88,13 +100,45 @@ class PDFParser(AbstractParser):
                     val = info.get(attr, "")
                     if val:
                         meta[label] = str(val)[:200]
+            self._add_xmp_metadata(reader, meta)
+            meta["JavaScript"] = "Present" if self._has_javascript(reader) else "Not present"
+            meta["Signatures"] = self._signature_summary(reader) or "None"
+            attachments = self._extract_attachments(reader)
+            meta["Attachments"] = f"{len(attachments)} file(s)"
+
+            revision_slices = self._split_revisions(raw)
+            meta["Revisions"] = str(len(revision_slices))
+            revisions: list[PdfRevision] = []
+            if len(revision_slices) > 1:
+                for rev_bytes in revision_slices:
+                    try:
+                        rev_reader = pypdf.PdfReader(BytesIO(rev_bytes), strict=False)
+                        if rev_reader.is_encrypted and password is not None:
+                            rev_reader.decrypt(password)
+                        revisions.append(PdfRevision(
+                            data=rev_bytes,
+                            text=self._extract_text(rev_reader),
+                            has_javascript=self._has_javascript(rev_reader),
+                            signatures=self._signature_summary(rev_reader) or "None",
+                            attachments=self._extract_attachments(rev_reader),
+                        ))
+                    except Exception:
+                        revisions.append(PdfRevision(
+                            rev_bytes, "[Unable to extract text for this revision]",
+                            False, "Unknown", [],
+                        ))
 
             return ParseResult(
                 viewer_type="pdf",
                 data=raw,
                 metadata=meta,
                 text_index=full_text[:4000],
-                viewer_hints={"extracted_text": full_text, "password": password},
+                viewer_hints={
+                    "extracted_text": full_text,
+                    "password": password,
+                    "attachments": attachments,
+                    "revisions": revisions,
+                },
             )
         except WrongPasswordError:
             raise
@@ -109,3 +153,150 @@ class PDFParser(AbstractParser):
                     "File size": f"{node.size:,} B",
                 },
             )
+
+    @staticmethod
+    def _extract_text(reader: Any) -> str:
+        pages: list[str] = []
+        for i, page in enumerate(reader.pages, 1):
+            try:
+                text = page.extract_text() or ""
+            except Exception:
+                text = ""
+            if text.strip():
+                pages.append(f"--- Page {i} ---\n{text.strip()}")
+        return "\n\n".join(pages) if pages else "[No extractable text in this PDF]"
+
+    @staticmethod
+    def _format_xmp_value(val: Any) -> str:
+        """dc_creator/dc_subject are RDF Seq -> list[str]; dc_title/
+        dc_description are RDF Alt -> dict[lang, str] (language
+        alternatives) -- pypdf returns both as native Python containers,
+        not flat strings, so they need formatting rather than str()."""
+        if isinstance(val, dict):
+            return val.get("x-default") or next(iter(val.values()), "")
+        if isinstance(val, (list, tuple)):
+            return ", ".join(str(v) for v in val)
+        return str(val)
+
+    @classmethod
+    def _add_xmp_metadata(cls, reader: Any, meta: dict[str, Any]) -> None:
+        """XMP is a metadata stream separate from the /Info dictionary --
+        a mismatch between the two (e.g. different tool names or dates) is
+        itself a forensic signal, so both are kept, never merged."""
+        try:
+            xmp = reader.xmp_metadata
+        except Exception:
+            xmp = None
+        if xmp is None:
+            return
+        for attr, label in (
+            ("dc_creator", "XMP Creator"),
+            ("dc_title", "XMP Title"),
+            ("dc_description", "XMP Description"),
+            ("xmp_creator_tool", "XMP Creator Tool"),
+            ("xmp_create_date", "XMP Create Date"),
+            ("xmp_modify_date", "XMP Modify Date"),
+            ("xmpmm_document_id", "XMP Document ID"),
+            ("xmpmm_instance_id", "XMP Instance ID"),
+        ):
+            try:
+                val = getattr(xmp, attr, None)
+            except Exception:
+                val = None
+            if val:
+                formatted = cls._format_xmp_value(val)
+                if formatted:
+                    meta[label] = formatted[:200]
+
+    @staticmethod
+    def _has_javascript(reader: Any) -> bool:
+        """Document-level JavaScript, per the two standard PDF-spec
+        locations (ISO 32000-1 12.6.4.16): the Catalog's /Names/JavaScript
+        name tree, and a /JavaScript /OpenAction. Does not recurse into
+        every annotation/form-field's own /AA (additional-actions) dict --
+        that would need a full object-graph walk, not attempted here."""
+        try:
+            catalog = reader.root_object
+            names = catalog.get("/Names")
+            if names is not None and "/JavaScript" in names:
+                return True
+            open_action = catalog.get("/OpenAction")
+            if open_action is not None and open_action.get("/S") == "/JavaScript":
+                return True
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _signature_summary(reader: Any) -> str:
+        """Signature form fields (ISO 32000-1 12.8): AcroForm /Fields
+        entries with /FT /Sig. Only top-level fields are checked, not
+        fields nested inside a /Kids hierarchy."""
+        try:
+            acroform = reader.root_object.get("/AcroForm")
+            if not acroform:
+                return ""
+            fields = acroform.get("/Fields") or []
+            total = 0
+            signed = 0
+            for f in fields:
+                field = f.get_object() if hasattr(f, "get_object") else f
+                if field.get("/FT") == "/Sig":
+                    total += 1
+                    if field.get("/V"):
+                        signed += 1
+            if total == 0:
+                return ""
+            return f"{signed}/{total} signature field(s) signed"
+        except Exception:
+            return ""
+
+    @staticmethod
+    def _extract_attachments(reader: Any) -> list[tuple[str, bytes]]:
+        """Embedded files (ISO 32000-1 7.11), exposed by pypdf as filename
+        -> list[bytes] since the /EmbeddedFiles name tree allows more than
+        one attachment under the same name."""
+        out: list[tuple[str, bytes]] = []
+        try:
+            for name, blobs in reader.attachments.items():
+                for blob in blobs:
+                    out.append((name, blob))
+        except Exception:
+            pass
+        return out
+
+    @staticmethod
+    def _split_revisions(raw: bytes) -> list[bytes]:
+        """Walk the /Prev trailer chain backward from the current (newest)
+        revision (ISO 32000-1 7.5.6/7.5.8: each incremental update's
+        trailer points at the byte offset of the previous revision's own
+        xref section). Truncating the file right after that earlier
+        revision's own %%EOF yields a byte string that is itself a
+        complete, independently parseable PDF -- verified directly against
+        hand-built multi-revision fixtures, not assumed. Returns
+        oldest-first; always at least [raw], even for a never-updated
+        file or one that fails to parse at all."""
+        import pypdf
+
+        revisions = [raw]
+        current = raw
+        seen_offsets: set[int] = set()
+        while True:
+            try:
+                r = pypdf.PdfReader(BytesIO(current), strict=False)
+                prev = r.trailer.get("/Prev")
+            except Exception:
+                break
+            if prev is None:
+                break
+            prev_offset = int(prev)
+            if prev_offset in seen_offsets:
+                break  # cyclic /Prev chain -- stop rather than loop forever
+            seen_offsets.add(prev_offset)
+            eof_pos = current.find(b"%%EOF", prev_offset)
+            if eof_pos == -1:
+                break
+            current = current[: eof_pos + len(b"%%EOF")]
+            revisions.append(current)
+        revisions.reverse()
+        return revisions

--- a/crush/viewers/pdf_viewer.py
+++ b/crush/viewers/pdf_viewer.py
@@ -3,19 +3,31 @@
 """PDF viewer — rendered pages (pypdfium2) alongside the extracted text."""
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QImage, QPixmap
+import difflib
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor, QFont, QImage, QPixmap, QTextCharFormat
 from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QFileDialog,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
+    QMenu,
+    QPlainTextEdit,
     QPushButton,
     QScrollArea,
     QSlider,
+    QStackedWidget,
+    QTableWidget,
+    QTableWidgetItem,
     QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from crush.parsers.pdf_parser import PdfRevision
 from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.text_viewer import TextView
 
@@ -166,9 +178,439 @@ class _PdfPagesView(QWidget):
         self._zoom_slider.setValue(int(scale * 100))
         self._zoom_slider.blockSignals(False)
 
+    def wheelEvent(self, event: object) -> None:  # type: ignore[override]
+        # Same Ctrl+wheel-to-zoom convention as image_viewer.py.
+        if hasattr(event, "modifiers") and hasattr(event, "angleDelta"):
+            if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+                delta = event.angleDelta().y()
+                if delta > 0:
+                    self._zoom_to(self._scale * 1.1)
+                elif delta < 0:
+                    self._zoom_to(self._scale / 1.1)
+                return
+        super().wheelEvent(event)  # type: ignore[arg-type]
+
+
+_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"]
+
+
+def _format_size(size: int) -> str:
+    """Mirrors fs_panel.py's _format_size -- kept local since this
+    codebase already has one small copy per module rather than a shared
+    utility for this."""
+    value = float(size)
+    unit_index = 0
+    while value >= 1024 and unit_index < len(_SIZE_UNITS) - 1:
+        value /= 1024
+        unit_index += 1
+    if unit_index == 0:
+        return f"{int(value)} {_SIZE_UNITS[unit_index]}"
+    return f"{value:.1f} {_SIZE_UNITS[unit_index]}"
+
+
+class _PdfAttachmentsView(QWidget):
+    """Embedded-file list (ISO 32000-1 7.11) -- double-click or right-click
+    -> Open as New Tab routes the bytes through the same generic
+    open_bytes_requested mechanism the BLOB Inspector / TableViewer already
+    use (see main_window.py's _open_bytes_as_artifact), so an attachment is
+    identified and displayed by whichever parser actually matches it,
+    rather than assuming it's any particular format."""
+
+    open_bytes_requested = Signal(bytes, str)
+
+    def __init__(
+        self, attachments: list[tuple[str, bytes]], parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._attachments = attachments
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self._table = QTableWidget(len(attachments), 2, self)
+        self._table.setHorizontalHeaderLabels(["Name", "Size"])
+        self._table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self._table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._table.customContextMenuRequested.connect(self._on_context_menu)
+        self._table.cellDoubleClicked.connect(lambda row, _col: self._open_as_new_tab(row))
+        for row, (name, data) in enumerate(attachments):
+            self._table.setItem(row, 0, QTableWidgetItem(name))
+            self._table.setItem(row, 1, QTableWidgetItem(_format_size(len(data))))
+        layout.addWidget(self._table)
+
+    def _open_as_new_tab(self, row: int) -> None:
+        name, data = self._attachments[row]
+        self.open_bytes_requested.emit(data, name)
+
+    def _export(self, row: int) -> None:
+        name, data = self._attachments[row]
+        path, _ = QFileDialog.getSaveFileName(self, "Export Attachment", name, "All files (*)")
+        if not path:
+            return
+        with open(path, "wb") as f:
+            f.write(data)
+
+    def _on_context_menu(self, pos: object) -> None:
+        row = self._table.rowAt(pos.y())  # type: ignore[attr-defined]
+        if row < 0:
+            return
+        menu = QMenu(self)
+        open_action = menu.addAction("Open as New Tab")
+        export_action = menu.addAction("Export…")
+        action = menu.exec(self._table.viewport().mapToGlobal(pos))  # type: ignore[arg-type]
+        if action == open_action:
+            self._open_as_new_tab(row)
+        elif action == export_action:
+            self._export(row)
+
+
+_DIFF_ADD_BG = QColor(46, 160, 67, 60)    # translucent green tint
+_DIFF_DEL_BG = QColor(220, 60, 60, 60)    # translucent red tint
+
+
+class _PdfDiffView(QWidget):
+    """Line-level text diff (stdlib difflib) between any two revisions --
+    picks the last two by default, since "what changed in the last save"
+    is the common question. Colors are translucent tints over whatever
+    the widget's actual background is, rather than a fixed opaque color,
+    so it reads reasonably across this app's Light/Dark/Geek/rainbow
+    themes without per-theme tuning.
+
+    Text-only: a black box drawn *over* text without touching the
+    underlying content stream changes nothing in extracted text between
+    revisions, so this catches content edits, not purely visual ones --
+    see the sibling "Visual" sub-tab (_PdfVisualDiffView) for a
+    pixel-level page diff, which does catch that case.
+    """
+
+    def __init__(self, revisions: list[PdfRevision], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._revisions = revisions
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        picker_row = QHBoxLayout()
+        picker_row.setSpacing(6)
+        picker_row.addWidget(QLabel("Compare:"))
+        self._combo_a = QComboBox()
+        self._combo_b = QComboBox()
+        for i, _rev in enumerate(revisions):
+            label = f"Revision {i + 1}" + (" (current)" if i == len(revisions) - 1 else "")
+            self._combo_a.addItem(label, i)
+            self._combo_b.addItem(label, i)
+        self._combo_a.setCurrentIndex(max(0, len(revisions) - 2))
+        self._combo_b.setCurrentIndex(len(revisions) - 1)
+        picker_row.addWidget(self._combo_a)
+        picker_row.addWidget(QLabel("→"))
+        picker_row.addWidget(self._combo_b)
+        picker_row.addStretch(1)
+        layout.addLayout(picker_row)
+
+        self._diff_view = QPlainTextEdit()
+        self._diff_view.setReadOnly(True)
+        font = QFont("Courier New", 10)
+        font.setStyleHint(QFont.StyleHint.Monospace)
+        self._diff_view.setFont(font)
+        layout.addWidget(self._diff_view)
+
+        self._combo_a.currentIndexChanged.connect(self._update_diff)
+        self._combo_b.currentIndexChanged.connect(self._update_diff)
+        self._update_diff()
+
+    def _update_diff(self) -> None:
+        idx_a = self._combo_a.currentData()
+        idx_b = self._combo_b.currentData()
+        self._diff_view.clear()
+        if idx_a is None or idx_b is None:
+            return
+        rev_a = self._revisions[idx_a]
+        rev_b = self._revisions[idx_b]
+        diff_lines = list(difflib.unified_diff(
+            rev_a.text.splitlines(), rev_b.text.splitlines(),
+            fromfile=f"Revision {idx_a + 1}", tofile=f"Revision {idx_b + 1}",
+            lineterm="", n=2,
+        ))
+        cursor = self._diff_view.textCursor()
+        if not diff_lines:
+            cursor.insertText("No text differences between these revisions.\n")
+            return
+        for line in diff_lines:
+            fmt = QTextCharFormat()
+            if line.startswith(("+++", "---")):
+                fmt.setForeground(QColor(128, 128, 128))
+            elif line.startswith("@@"):
+                fmt.setForeground(QColor(96, 160, 200))
+            elif line.startswith("+"):
+                fmt.setBackground(_DIFF_ADD_BG)
+            elif line.startswith("-"):
+                fmt.setBackground(_DIFF_DEL_BG)
+            cursor.insertText(line + "\n", fmt)
+
+
+def _render_pdf_page_pil(data: bytes, password: str | None, page_index: int) -> object | None:
+    """Render one page of a PDF revision slice to a PIL RGB Image, or
+    None if the page doesn't exist / the slice fails to open."""
+    try:
+        import pypdfium2 as pdfium
+
+        doc = pdfium.PdfDocument(data, password=password)
+        if page_index >= len(doc):
+            return None
+        bitmap = doc[page_index].render(scale=_RENDER_SCALE)
+        return bitmap.to_pil().convert("RGB")
+    except Exception:
+        return None
+
+
+def _pdf_page_count(data: bytes, password: str | None) -> int:
+    try:
+        import pypdfium2 as pdfium
+
+        return len(pdfium.PdfDocument(data, password=password))
+    except Exception:
+        return 0
+
+
+class _PdfVisualDiffView(QWidget):
+    """Pixel-level page diff between two revisions -- catches purely
+    visual changes a text diff can't see, e.g. a black redaction box
+    drawn *over* text whose underlying content stream is untouched (no
+    text-diff signal at all), or a swapped/removed image. Differing
+    pixels (per-channel luminance difference above a small noise
+    threshold) are highlighted with a translucent red overlay on top of
+    the newer revision's own rendering.
+
+    Rendered on demand when the revision pair or page changes, not
+    cached -- there are O(N^2) possible revision pairs, so caching every
+    combination isn't worth it; a single re-render is cheap enough.
+    """
+
+    _DIFF_THRESHOLD = 24  # luminance-difference noise floor, not a guess
+    # at content -- pypdfium2 renders deterministically, so any value
+    # above this for a truly identical source page would itself be a bug
+    # worth seeing, not something to hide by raising the threshold further.
+
+    def __init__(
+        self, revisions: list[PdfRevision], password: str | None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._revisions = revisions
+        self._password = password
+        self._page = 0
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        picker_row = QHBoxLayout()
+        picker_row.setSpacing(6)
+        picker_row.addWidget(QLabel("Compare:"))
+        self._combo_a = QComboBox()
+        self._combo_b = QComboBox()
+        for i, _rev in enumerate(revisions):
+            label = f"Revision {i + 1}" + (" (current)" if i == len(revisions) - 1 else "")
+            self._combo_a.addItem(label, i)
+            self._combo_b.addItem(label, i)
+        self._combo_a.setCurrentIndex(max(0, len(revisions) - 2))
+        self._combo_b.setCurrentIndex(len(revisions) - 1)
+        picker_row.addWidget(self._combo_a)
+        picker_row.addWidget(QLabel("→"))
+        picker_row.addWidget(self._combo_b)
+        picker_row.addSpacing(16)
+        self._prev_btn = QPushButton("◀ Prev page")
+        self._prev_btn.clicked.connect(self._prev_page)
+        picker_row.addWidget(self._prev_btn)
+        self._page_label = QLabel("")
+        picker_row.addWidget(self._page_label)
+        self._next_btn = QPushButton("Next page ▶")
+        self._next_btn.clicked.connect(self._next_page)
+        picker_row.addWidget(self._next_btn)
+        picker_row.addStretch(1)
+        layout.addLayout(picker_row)
+
+        self._status_label = QLabel("")
+        self._status_label.setWordWrap(True)
+        self._status_label.setStyleSheet("padding: 2px 8px;")
+        layout.addWidget(self._status_label)
+
+        self._scroll = QScrollArea()
+        self._scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._scroll.setWidgetResizable(False)
+        install_horizontal_wheel_scroll(self._scroll, smooth_item_scroll=False)
+        self._image_label = QLabel()
+        self._image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._scroll.setWidget(self._image_label)
+        layout.addWidget(self._scroll)
+
+        self._combo_a.currentIndexChanged.connect(self._on_pair_changed)
+        self._combo_b.currentIndexChanged.connect(self._on_pair_changed)
+        self._update()
+
+    def _on_pair_changed(self) -> None:
+        self._page = 0
+        self._update()
+
+    def _prev_page(self) -> None:
+        if self._page > 0:
+            self._page -= 1
+            self._update()
+
+    def _next_page(self) -> None:
+        self._page += 1
+        self._update()
+
+    def _update(self) -> None:
+        idx_a = self._combo_a.currentData()
+        idx_b = self._combo_b.currentData()
+        if idx_a is None or idx_b is None:
+            return
+        rev_a = self._revisions[idx_a]
+        rev_b = self._revisions[idx_b]
+
+        page_count = max(
+            _pdf_page_count(rev_a.data, self._password),
+            _pdf_page_count(rev_b.data, self._password),
+        )
+        self._page_label.setText(f"Page {self._page + 1} / {max(page_count, 1)}")
+        self._prev_btn.setEnabled(self._page > 0)
+        self._next_btn.setEnabled(self._page + 1 < page_count)
+
+        img_a = _render_pdf_page_pil(rev_a.data, self._password, self._page)
+        img_b = _render_pdf_page_pil(rev_b.data, self._password, self._page)
+        if img_a is None or img_b is None:
+            self._status_label.setText(
+                "This page doesn't exist in one of the two selected revisions."
+            )
+            self._image_label.clear()
+            return
+        if img_a.size != img_b.size:
+            self._status_label.setText(
+                f"Page size differs between revisions ({img_a.size[0]}×{img_a.size[1]} vs "
+                f"{img_b.size[0]}×{img_b.size[1]}) -- not diffed to avoid a misleading "
+                "resize; showing the newer revision only."
+            )
+            pixmap = _pil_to_pixmap(img_b)
+            self._image_label.setPixmap(pixmap)
+            self._image_label.resize(pixmap.size())
+            return
+
+        from PIL import Image, ImageChops
+
+        diff_gray = ImageChops.difference(img_a, img_b).convert("L")
+        mask = diff_gray.point(lambda p: 255 if p > self._DIFF_THRESHOLD else 0)
+        changed_px = mask.histogram()[255]
+        total_px = mask.size[0] * mask.size[1]
+
+        if changed_px == 0:
+            self._status_label.setText("No visual differences on this page.")
+            pixmap = _pil_to_pixmap(img_b)
+        else:
+            pct = 100.0 * changed_px / total_px
+            self._status_label.setText(
+                f"{pct:.2f}% of pixels differ on this page (highlighted in red)."
+            )
+            red_layer = Image.new("RGBA", img_b.size, (255, 0, 0, 130))
+            overlay = Image.new("RGBA", img_b.size, (255, 0, 0, 0))
+            overlay.paste(red_layer, mask=mask)
+            composited = img_b.convert("RGBA")
+            composited.alpha_composite(overlay)
+            pixmap = _pil_to_pixmap(composited)
+
+        self._image_label.setPixmap(pixmap)
+        self._image_label.resize(pixmap.size())
+
+
+class _PdfHistoryView(QWidget):
+    """Revision-by-revision view of a PDF's incremental-update chain
+    (see PDFParser._split_revisions / PdfRevision). Each revision is a
+    complete, independently valid PDF slice -- earlier ones may show
+    content ("redacted" text, removed images, a JavaScript payload or
+    attachment later stripped) that the current/final revision no longer
+    exposes. Three sub-tabs: Browse (one revision at a time, full
+    Pages/Text/Attachments), Diff (line-level text diff between any two
+    revisions -- see _PdfDiffView), and Visual (pixel-level page diff --
+    see _PdfVisualDiffView).
+
+    Built lazily: only the currently selected revision's sub-view is
+    constructed, and it's cached afterward -- the same "don't do work
+    nobody asked for" rule _PdfPagesView already applies per-page,
+    extended here to per-revision (N revisions x M pages would otherwise
+    all render up front).
+    """
+
+    open_bytes_requested = Signal(bytes, str)
+
+    def __init__(
+        self, revisions: list[PdfRevision], password: str | None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._revisions = revisions
+        self._password = password
+        self._built: dict[int, QWidget] = {}
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        sub_tabs = QTabWidget()
+        sub_tabs.addTab(self._build_browse_tab(), "Browse")
+        sub_tabs.addTab(_PdfDiffView(revisions, sub_tabs), "Text Diff")
+        sub_tabs.addTab(_PdfVisualDiffView(revisions, password, sub_tabs), "Visual Diff")
+        layout.addWidget(sub_tabs)
+
+    def _build_browse_tab(self) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        selector_row = QHBoxLayout()
+        selector_row.setSpacing(4)
+        for i, rev in enumerate(self._revisions):
+            label = f"Revision {i + 1}" + (" (current)" if i == len(self._revisions) - 1 else "")
+            if rev.has_javascript or rev.signatures != "None" or rev.attachments:
+                label += " ⚠"
+            btn = QPushButton(label)
+            btn.clicked.connect(lambda _checked=False, idx=i: self._select(idx))
+            selector_row.addWidget(btn)
+        selector_row.addStretch(1)
+        layout.addLayout(selector_row)
+
+        self._stack = QStackedWidget()
+        layout.addWidget(self._stack)
+        self._select(0)
+        return container
+
+    def _select(self, index: int) -> None:
+        if index not in self._built:
+            self._built[index] = self._build_revision_view(self._revisions[index])
+            self._stack.addWidget(self._built[index])
+        self._stack.setCurrentWidget(self._built[index])
+
+    def _build_revision_view(self, rev: PdfRevision) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        info = QLabel(
+            f"JavaScript: {'Present' if rev.has_javascript else 'Not present'}"
+            f"    ·    Signatures: {rev.signatures}"
+            f"    ·    Attachments: {len(rev.attachments)} file(s)"
+        )
+        info.setStyleSheet("padding: 4px 8px; color: palette(mid);")
+        layout.addWidget(info)
+
+        tabs = QTabWidget()
+        tabs.addTab(_PdfPagesView(rev.data, self._password, tabs), "Pages")
+        tabs.addTab(TextView(rev.text, tabs), "Text")
+        if rev.attachments:
+            attachments_view = _PdfAttachmentsView(rev.attachments, tabs)
+            attachments_view.open_bytes_requested.connect(self.open_bytes_requested)
+            tabs.addTab(attachments_view, f"Attachments ({len(rev.attachments)})")
+        layout.addWidget(tabs)
+        return container
+
 
 class PDFViewer(QWidget):
-    """Tabbed PDF viewer: rendered pages plus the parser's extracted text."""
+    """Tabbed PDF viewer: rendered pages plus the parser's extracted text
+    and, when present, Attachments and History tabs."""
+
+    open_bytes_requested = Signal(bytes, str)
 
     def __init__(
         self,
@@ -176,6 +618,8 @@ class PDFViewer(QWidget):
         parent: QWidget | None = None,
         extracted_text: str = "",
         password: str | None = None,
+        attachments: list[tuple[str, bytes]] | None = None,
+        revisions: list[PdfRevision] | None = None,
     ) -> None:
         super().__init__(parent)
         layout = QVBoxLayout(self)
@@ -183,4 +627,12 @@ class PDFViewer(QWidget):
         tabs = QTabWidget()
         tabs.addTab(_PdfPagesView(data, password, self), "Pages")
         tabs.addTab(TextView(extracted_text, self), "Text")
+        if attachments:
+            attachments_view = _PdfAttachmentsView(attachments, self)
+            attachments_view.open_bytes_requested.connect(self.open_bytes_requested)
+            tabs.addTab(attachments_view, f"Attachments ({len(attachments)})")
+        if revisions:
+            history_view = _PdfHistoryView(revisions, password, self)
+            history_view.open_bytes_requested.connect(self.open_bytes_requested)
+            tabs.addTab(history_view, f"History ({len(revisions)})")
         layout.addWidget(tabs)


### PR DESCRIPTION
- Properties panel: PDF version, XMP metadata (kept separate from /Info -- a mismatch between the two is itself a forensic signal), and always-shown JavaScript/Signatures/Attachments/Revisions fields.
- Embedded files get an Attachments tab (open as new tab or export).
- PDFs saved multiple times (incremental updates, walked via each trailer's /Prev chain) get a History tab: Browse (per-revision  Pages/Text/Attachments, JS/signature/attachment-only revisions flagged with a warning marker), Text Diff (difflib between any two revisions), and Visual Diff (pixel-level page comparison -- catches a redaction box drawn over text that a text diff can't see).
- Pages tab: Ctrl+scroll wheel zoom, same convention as Image viewer.