### PR TITLE
feat: Blob Inspector schema-based Protobuf decode; fix open_vfs error…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ All notable changes to Crush will be documented in this file.
 - **Properties panel shows the original iTunes backup file ID** — the raw `fileID`-named path (e.g. `ab/ab54f7c9...e1`) is now shown alongside the resolved `domain/relativePath`, for files only. Addresses [#41](https://github.com/kalink0/crush-forensics/issues/41).
 - **PDF viewer renders pages, not just text** — double-clicking a PDF now shows a "Pages" tab with page-by-page rendering (via `pypdfium2`) and navigation/zoom (also via Ctrl+scroll wheel, same as the Image viewer), alongside the existing extracted-text "Text" tab. Password-protected PDFs are supported via **Open as → PDF (Encrypted)…**.
 - **PDF: extended metadata, attachments, and revision history** — Properties panel gains PDF version, XMP metadata, and always-shown JavaScript/Signatures/Attachments/Revisions fields; embedded files get their own **Attachments** tab. PDFs saved multiple times get a **History** tab exposing every revision (including content/JS/attachments since removed from the current one), with **Text Diff** and **Visual Diff** (pixel-level page comparison) between any two revisions.
+- **Blob Inspector: schema-based Protobuf decode** — selecting **Protobuf (schema-less)** now reveals a **Load .proto schema…** toolbar; loading a `.proto`/`.pb`/`.desc`/`.fds` file and picking a message type decodes the blob with real field names, using the same schema loader the standalone Protobuf Viewer already had.
 
 ### Bug Fixes
 
 - **Rainbow/'Merica theme: dialog buttons stopped responding to clicks** — the animated-theme timer's stylesheet refresh already skipped open menus to avoid a re-polish flicker, but not open modal dialogs (`QMessageBox` etc.), where the same re-polish could eat a button click. Now skipped for both.
+- **Protobuf Viewer's schema-based decode was broken on current protobuf versions** — `MessageFactory.GetPrototype` was removed in protobuf 6.x and `including_default_value_fields` was renamed to `always_print_fields_with_no_presence`; both call sites now use the current API.
+- **Opening a moved/deleted file from Open Recent showed "Unsupported source type"** — `open_vfs()` fell through to that generic error whenever a path didn't exist instead of checking existence first; now raises a clear "File no longer exists" error.
 
 ## v0.14.0 - 2026-07-12
 

--- a/crush/core/vfs.py
+++ b/crush/core/vfs.py
@@ -1074,6 +1074,8 @@ def _find_node_by_path(node: VFSNode, path: str) -> "VFSNode | None":
 def open_vfs(path: str | Path, *, password: str = "") -> VFS:
     """Factory — open the right VFS type based on the source path."""
     p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"File no longer exists: {p}")
     if p.is_dir():
         if _is_itunes_backup_dir(p):
             return ITunesBackupVFS(p, password=password)

--- a/crush/docs/format-support.md
+++ b/crush/docs/format-support.md
@@ -240,6 +240,7 @@ Limitations
 - Schema-less decode in a tree view (field numbers, wire types, values).
 - Wire type 2 (length-delimited) doesn't declare whether a payload is a nested message, a string, or opaque bytes — a field is rendered as a nested message when its bytes happen to parse as one, but a dimmed "raw bytes" hint is always shown alongside it, the same way numeric fields show every plausible interpretation, since a short blob can coincidentally be grammatically valid protobuf without actually being a submessage.
 - Optional schema-based decode after loading a `.proto` file or descriptor set.
+- The **Blob Inspector** (any BLOB field, not just files opened as Protobuf) offers the same schema-based decode: select **Protobuf (schema-less)** first, then a schema-loading toolbar appears above the content view.
 
 Limitations
 - Schema-based decoding depends on the protobuf Python library and valid schemas.

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -401,9 +401,12 @@ After the pipeline runs, the resulting bytes are tested against all available in
 | **Android Binary XML (ABX)** | ✓ | Reconstructs XML from Android's compact binary XML format |
 | **Image** | ✓ | Renders the image inline — PNG, JPEG, GIF, BMP, WebP, HEIC, AVIF |
 | **Protobuf (schema-less)** | ~ | Wire-format decode. Numeric fields include `# label: value` hints for int64, sint64 (zigzag), bool, Unix/Cocoa/Chrome timestamps, double, and float; a field shown as a nested message also gets a `# raw bytes: ...` hint, since wire type 2 doesn't actually declare whether the bytes are a submessage. A `# Warning:` header appears if the parse was truncated or malformed. Shown as **~** because Protobuf's wire format accepts most byte sequences. |
+| **Protobuf (schema: `<type>`)** | ✓ | Only appears once a schema is loaded (see below) — decodes using real field names and types instead of raw wire format. |
 | **Latin-1 text** | ~ | ISO-8859-1 — always succeeds since every byte is a valid Latin-1 character; useful as a last resort for mixed binary/text data |
 
 **Auto-selection:** when the inspector opens or the pipeline changes, the best ✓-tier interpretation is selected automatically. If the previously selected format still produces output after a pipeline change, the selection is preserved.
+
+**Schema-based Protobuf decode:** select **Protobuf (schema-less)** first to confirm the bytes decode plausibly as Protobuf — a *Load .proto schema…* toolbar then appears above the content view. Load a `.proto` source file or a compiled FileDescriptorSet (`.pb`, `.fds`, `.desc`) and pick a message type from the dropdown; the view switches to a **Protobuf (schema: `<type>`)** entry decoded with real field names via that schema. The toolbar only shows while a Protobuf entry is selected — it stays out of the way for every other format. Uses the same schema loader as the standalone [Protobuf Viewer](#protobuf-viewer); the loaded schema is kept only for this inspector window's lifetime.
 
 ---
 

--- a/crush/parsers/protobuf_schema.py
+++ b/crush/parsers/protobuf_schema.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Shared protobuf schema loading, used by ProtobufViewer and the Blob Inspector.
+
+Loads a .proto/.pb/.desc/.fds file into a DescriptorPool + message type list,
+and decodes raw bytes against a chosen message type from that pool.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class SchemaLoadError(Exception):
+    """Raised when a schema file can't be loaded, compiled, or parsed."""
+
+
+def compile_proto(path: Path) -> bytes:
+    """Compile a .proto file to a serialized FileDescriptorSet via grpcio-tools."""
+    try:
+        from grpc_tools import protoc
+    except Exception as exc:
+        raise SchemaLoadError(".proto requires grpcio-tools or a .pb descriptor set") from exc
+
+    import tempfile
+
+    out_path = Path(tempfile.mkdtemp()) / "descriptor.fds"
+    args = [
+        "protoc",
+        f"-I{path.parent}",
+        f"--descriptor_set_out={out_path}",
+        "--include_imports",
+        str(path),
+    ]
+    rc = protoc.main(args)
+    if rc != 0 or not out_path.exists():
+        raise SchemaLoadError("Failed to compile .proto file")
+    return out_path.read_bytes()
+
+
+def collect_message_names(fds: Any) -> list[str]:
+    """Flatten all (including nested) message type names out of a FileDescriptorSet."""
+    names: list[str] = []
+
+    def walk(prefix: str, msg: Any) -> None:
+        full = f"{prefix}.{msg.name}" if prefix else msg.name
+        names.append(full)
+        for nested in msg.nested_type:
+            walk(full, nested)
+
+    for fd in fds.file:
+        pkg = fd.package or ""
+        for msg in fd.message_type:
+            walk(pkg, msg)
+
+    names.sort()
+    return names
+
+
+def load_descriptor_set(path: Path) -> dict[str, Any]:
+    """Load a .proto/.pb/.desc/.fds file into a DescriptorPool + message name list.
+
+    Returns {"pool": DescriptorPool, "message_names": list[str]}.
+    Raises SchemaLoadError with a user-facing message on any failure.
+    """
+    try:
+        from google.protobuf import descriptor_pb2, descriptor_pool
+    except Exception as exc:
+        raise SchemaLoadError("Install protobuf to use schema decoding") from exc
+
+    if path.suffix.lower() == ".proto":
+        data = compile_proto(path)
+    else:
+        data = path.read_bytes()
+
+    fds = descriptor_pb2.FileDescriptorSet()
+    try:
+        fds.ParseFromString(data)
+    except Exception as exc:
+        raise SchemaLoadError("Invalid descriptor set") from exc
+
+    pool = descriptor_pool.DescriptorPool()
+    for fd in fds.file:
+        pool.Add(fd)
+
+    message_names = collect_message_names(fds)
+    if not message_names:
+        raise SchemaLoadError("No message types found")
+
+    return {"pool": pool, "message_names": message_names}
+
+
+def decode_message_with_schema(pool: Any, message_name: str, raw: bytes) -> Any:
+    """Parse raw bytes as message_name using pool. Returns the populated message object."""
+    from google.protobuf import message_factory
+
+    descriptor = pool.FindMessageTypeByName(message_name)
+    cls = message_factory.GetMessageClass(descriptor)
+    msg = cls()
+    msg.ParseFromString(raw)
+    return msg

--- a/crush/tests/test_vfs.py
+++ b/crush/tests/test_vfs.py
@@ -65,6 +65,12 @@ def test_open_vfs_directory(tmp_path: Path) -> None:
     assert isinstance(vfs, DirectoryVFS)
 
 
+def test_open_vfs_missing_path_raises_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.db"
+    with pytest.raises(FileNotFoundError, match="no longer exists"):
+        open_vfs(missing)
+
+
 def test_open_vfs_zip(tmp_path: Path) -> None:
     zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:

--- a/crush/viewers/blob_inspector.py
+++ b/crush/viewers/blob_inspector.py
@@ -8,13 +8,16 @@ import gzip
 import json as _json
 import zlib
 from collections.abc import Callable
+from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QContextMenuEvent, QPixmap
 from PySide6.QtWidgets import (
     QApplication,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
+    QFileDialog,
     QHBoxLayout,
     QLabel,
     QListWidget,
@@ -32,6 +35,11 @@ from crush.core.formatters import (
     bytes_to_hexview,
     try_plist_text,
     try_xml_text,
+)
+from crush.parsers.protobuf_schema import (
+    SchemaLoadError,
+    decode_message_with_schema,
+    load_descriptor_set,
 )
 from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 
@@ -203,6 +211,10 @@ def _is_image(data: bytes) -> bool:
     )
 
 
+def _is_protobuf_entry(name: str) -> bool:
+    return name == "Protobuf (schema-less)" or name.startswith("Protobuf (schema: ")
+
+
 def _render_protobuf(entries: list, indent: int = 0) -> str:
     lines: list[str] = []
     pad = "  " * indent
@@ -323,6 +335,8 @@ class _BlobPanel(QWidget):
         self._cached_results: dict[str, str] = {}
         self._cached_image_data: bytes | None = None
         self._hex_mode = False
+        self._schema_pool = None
+        self._schema_message: str | None = None
         self._build_panel()
         self._recompute()
 
@@ -385,6 +399,28 @@ class _BlobPanel(QWidget):
         content_col.setContentsMargins(4, 0, 0, 0)
         content_col.setSpacing(4)
 
+        self._schema_toolbar = QWidget()
+        schema_row = QHBoxLayout(self._schema_toolbar)
+        schema_row.setContentsMargins(0, 0, 0, 0)
+        schema_row.setSpacing(4)
+        self._schema_load_btn = QPushButton("Load .proto schema…")
+        self._schema_load_btn.setToolTip("Load a .proto/.pb/.desc/.fds schema for Protobuf decoding")
+        self._schema_load_btn.clicked.connect(self._on_load_schema)
+        schema_row.addWidget(self._schema_load_btn)
+        self._schema_combo = QComboBox()
+        self._schema_combo.setPlaceholderText("No schema loaded")
+        self._schema_combo.setEnabled(False)
+        self._schema_combo.currentTextChanged.connect(self._on_schema_message_changed)
+        schema_row.addWidget(self._schema_combo, stretch=1)
+        self._schema_clear_btn = QPushButton("✕")
+        self._schema_clear_btn.setFixedWidth(22)
+        self._schema_clear_btn.setToolTip("Clear loaded schema")
+        self._schema_clear_btn.setEnabled(False)
+        self._schema_clear_btn.clicked.connect(self._on_clear_schema)
+        schema_row.addWidget(self._schema_clear_btn)
+        self._schema_toolbar.setVisible(False)
+        content_col.addWidget(self._schema_toolbar)
+
         self._stack = QStackedWidget()
 
         self._viewer = _BlobViewerEdit(self)
@@ -420,6 +456,57 @@ class _BlobPanel(QWidget):
 
         outer.addWidget(splitter, stretch=1)
 
+    def _on_load_schema(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Protobuf schema",
+            "",
+            "Protobuf schema (*.proto *.pb *.desc *.fds);;All files (*)",
+        )
+        if not path:
+            return
+        try:
+            loaded = load_descriptor_set(Path(path))
+        except SchemaLoadError as exc:
+            self._viewer.setPlainText(f"[schema load failed: {exc}]")
+            return
+        self._schema_pool = loaded["pool"]
+        self._schema_combo.blockSignals(True)
+        self._schema_combo.clear()
+        self._schema_combo.addItems(loaded["message_names"])
+        self._schema_combo.setCurrentIndex(0)
+        self._schema_combo.blockSignals(False)
+        self._schema_combo.setEnabled(True)
+        self._schema_clear_btn.setEnabled(True)
+        self._schema_message = self._schema_combo.currentText() or None
+        self._recompute()
+        if self._schema_message:
+            self._select_format(f"Protobuf (schema: {self._schema_message})")
+
+    def _on_clear_schema(self) -> None:
+        self._schema_pool = None
+        self._schema_message = None
+        self._schema_combo.blockSignals(True)
+        self._schema_combo.clear()
+        self._schema_combo.blockSignals(False)
+        self._schema_combo.setEnabled(False)
+        self._schema_clear_btn.setEnabled(False)
+        self._recompute()
+        self._select_format("Protobuf (schema-less)")
+
+    def _on_schema_message_changed(self, name: str) -> None:
+        self._schema_message = name or None
+        self._recompute()
+        if self._schema_message:
+            self._select_format(f"Protobuf (schema: {self._schema_message})")
+
+    def _select_format(self, name: str) -> None:
+        for i in range(self._format_list.count()):
+            item = self._format_list.item(i)
+            if item and item.data(Qt.ItemDataRole.UserRole) == name:
+                self._format_list.setCurrentItem(item)
+                return
+
     def _push_step(self) -> None:
         number = len(self._steps) + 1
         step = _StepRow(number, self)
@@ -453,6 +540,7 @@ class _BlobPanel(QWidget):
                 self._stack.setCurrentIndex(0)
                 self._hex_mode = False
                 self._copy_btn.setEnabled(False)
+                self._schema_toolbar.setVisible(False)
                 return
             step.set_hint(f"→ {len(result):,} B")
             current = result
@@ -489,6 +577,21 @@ class _BlobPanel(QWidget):
                     confident.append(key)
             else:
                 failed.append(key)
+
+        if self._schema_pool is not None and self._schema_message:
+            label = f"Protobuf (schema: {self._schema_message})"
+            try:
+                from google.protobuf import json_format
+                msg = decode_message_with_schema(self._schema_pool, self._schema_message, data)
+                self._cached_results[label] = json_format.MessageToJson(
+                    msg,
+                    preserving_proto_field_name=True,
+                    always_print_fields_with_no_presence=True,
+                )
+                confident.append(label)
+            except Exception as exc:
+                self._cached_results[label] = f"[schema decode failed: {exc}]"
+                failed.append(label)
 
         self._cached_results["Hex view"] = bytes_to_hexview(data, max_bytes=200_000)
 
@@ -569,6 +672,8 @@ class _BlobPanel(QWidget):
     def _on_format_selected(self, name: str) -> None:
         if not name:
             return
+
+        self._schema_toolbar.setVisible(_is_protobuf_entry(name))
 
         if name == "Image":
             if self._cached_image_data is not None:

--- a/crush/viewers/protobuf_viewer.py
+++ b/crush/viewers/protobuf_viewer.py
@@ -18,6 +18,11 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from crush.parsers.protobuf_schema import (
+    SchemaLoadError,
+    decode_message_with_schema,
+    load_descriptor_set,
+)
 from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.tree_viewer import TreeViewer
 
@@ -124,8 +129,10 @@ class ProtobufViewer(QWidget):
         )
         if not path:
             return
-        loaded = self._load_descriptor_set(Path(path))
-        if loaded is None:
+        try:
+            loaded = load_descriptor_set(Path(path))
+        except SchemaLoadError as exc:
+            self._status.setText(str(exc))
             return
         self._descriptor_set = loaded
         self._pool = loaded["pool"]
@@ -139,39 +146,6 @@ class ProtobufViewer(QWidget):
         self._schema_label.setStyleSheet("color: palette(text);")
         self._status.setText(f"Loaded {len(self._message_names)} message types")
 
-    def _load_descriptor_set(self, path: Path) -> dict[str, Any] | None:
-        try:
-            from google.protobuf import descriptor_pb2, descriptor_pool
-        except Exception:
-            self._status.setText("Install protobuf to use schema decoding")
-            return None
-
-        if path.suffix.lower() == ".proto":
-            compiled = _compile_proto(path)
-            if compiled is None:
-                self._status.setText(".proto requires grpcio-tools or a .pb descriptor set")
-                return None
-            data = compiled
-        else:
-            data = path.read_bytes()
-
-        fds = descriptor_pb2.FileDescriptorSet()
-        try:
-            fds.ParseFromString(data)
-        except Exception:
-            self._status.setText("Invalid descriptor set")
-            return None
-
-        pool = descriptor_pool.DescriptorPool()
-        for fd in fds.file:
-            pool.Add(fd)
-
-        message_names = _collect_message_names(fds)
-        if not message_names:
-            self._status.setText("No message types found")
-            return None
-        return {"pool": pool, "message_names": message_names}
-
     def _decode_with_schema(self) -> None:
         if self._pool is None:
             self._status.setText("Load a schema first")
@@ -181,15 +155,12 @@ class ProtobufViewer(QWidget):
             self._status.setText("Select a message type")
             return
         try:
-            from google.protobuf import json_format, message_factory
-            descriptor = self._pool.FindMessageTypeByName(name)
-            cls = message_factory.MessageFactory(self._pool).GetPrototype(descriptor)
-            msg = cls()
-            msg.ParseFromString(self._raw)
+            from google.protobuf import json_format
+            msg = decode_message_with_schema(self._pool, name, self._raw)
             decoded = json_format.MessageToDict(
                 msg,
                 preserving_proto_field_name=True,
-                including_default_value_fields=True,
+                always_print_fields_with_no_presence=True,
             )
         except Exception as exc:
             self._status.setText(f"Decode failed: {exc}")
@@ -284,52 +255,3 @@ class ProtobufTreeWidget(QWidget):
             # Recurse into nested messages
             if isinstance(val, dict) and val.get("type") == "message":
                 self._populate(val.get("entries", []), field_item)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _compile_proto(path: Path) -> bytes | None:
-    """Compile a .proto file to a FileDescriptorSet using grpcio-tools if available."""
-    try:
-        from grpc_tools import protoc
-    except Exception:
-        return None
-
-    import tempfile
-
-    out_path = Path(tempfile.mkdtemp()) / "descriptor.fds"
-    args = [
-        "protoc",
-        f"-I{path.parent}",
-        f"--descriptor_set_out={out_path}",
-        "--include_imports",
-        str(path),
-    ]
-    try:
-        rc = protoc.main(args)
-        if rc != 0 or not out_path.exists():
-            return None
-        return out_path.read_bytes()
-    except Exception:
-        return None
-
-
-def _collect_message_names(fds: Any) -> list[str]:
-    names: list[str] = []
-
-    def walk(prefix: str, msg: Any) -> None:
-        full = f"{prefix}.{msg.name}" if prefix else msg.name
-        names.append(full)
-        for nested in msg.nested_type:
-            walk(full, nested)
-
-    for fd in fds.file:
-        pkg = fd.package or ""
-        for msg in fd.message_type:
-            walk(pkg, msg)
-
-    names.sort()
-    return names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["sqlcipher3", "sqlcipher3.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["google.protobuf", "google.protobuf.*", "grpc_tools", "grpc_tools.*"]
+ignore_missing_imports = true


### PR DESCRIPTION
… for missing files

Blob Inspector can now load a .proto/.pb/.desc/.fds schema to decode Protobuf BLOBs with real field names, sharing the loader with the standalone Protobuf Viewer (which also gets two protobuf 6.x API-drift fixes along the way). Also fixes open_vfs() showing "Unsupported source type" instead of a clear "File no longer exists" error when opening a moved/deleted file via Open Recent.