### PR TITLE
feat: add --open/positional CLI args to load evidence on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Crush will be documented in this file.
 - Added "Send to Peach" (right-click an AUL source, or any log file): hands the source off to the bundled peach-forensics log viewer.
 - Added Tools -> Peach -> Open Peach: launches peach standalone, no source pre-filled.
 - Added multi-file and recursive-folder handoff to Peach (multi-select in the tree, or right-click a folder) — sends multiple sources to one peach session at once.
+- Added CLI arguments: `crush PATH [PATH ...]` / `crush --open PATH` open one or more files/folders on startup, for other tools to invoke Crush with evidence pre-loaded.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ python -m crush
 
 If you see missing Qt or media errors, install the system dependencies below.
 
+### CLI arguments
+
+```bash
+crush /path/to/evidence.zip /path/to/case_folder
+crush --open /path/to/evidence.zip --open /path/to/case_folder
+```
+
+Positional paths and `--open PATH` (repeatable) are equivalent — each opens
+that file or folder on startup, added to the same window's tree. Every
+invocation opens a new window.
+
 ## System Dependencies
 
 Some Python packages require OS-level libraries on fresh machines.

--- a/crush/__main__.py
+++ b/crush/__main__.py
@@ -1,6 +1,25 @@
 """Entry point."""
+import argparse
 import os
 import sys
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="crush", description="Crush — Digital Forensic Analysis Workbench")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        metavar="PATH",
+        help="File(s) or folder(s) to open on startup (shorthand for --open PATH)",
+    )
+    parser.add_argument(
+        "--open",
+        action="append",
+        dest="open_paths",
+        metavar="PATH",
+        help="File or folder to open on startup (repeatable)",
+    )
+    return parser.parse_args(argv)
 
 
 def _icon_path() -> str:
@@ -15,6 +34,9 @@ def _icon_path() -> str:
 
 
 def main() -> None:
+    args = _parse_args(sys.argv[1:])
+    open_paths = list(args.paths) + list(args.open_paths or [])
+
     import crush
     from PySide6.QtGui import QIcon
     from PySide6.QtWidgets import QApplication
@@ -34,6 +56,8 @@ def main() -> None:
         app.setWindowIcon(QIcon(icon_path))
     window = MainWindow()
     window.show()
+    for path in open_paths:
+        window._load_source(path, open_after_load=True, append_to_tree=True)
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -21,6 +21,8 @@ Opening a file (**Open file…**) appends it to the existing tree as a new root 
 
 You can also **drag and drop** files, archives, or folders straight onto the Crush window instead of using the File menu — it follows the exact same rule: a dropped file appends, a dropped folder or archive (anything that opens as its own browsable tree) replaces. Dropping several items at once loads them one after another. Works the same on Windows, macOS, and Linux.
 
+A third way: pass paths on the command line — `crush /path/to/evidence.zip /path/to/case_folder` or `crush --open /path/to/evidence.zip` (repeatable) — to have Crush open them on startup instead of loading manually. Each invocation opens a fresh window. Useful for launching Crush from another tool with evidence already queued up.
+
 ---
 
 ## The Interface

--- a/crush/tests/test_cli_args.py
+++ b/crush/tests/test_cli_args.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CLI argument parsing (crush __main__)."""
+from __future__ import annotations
+
+from crush.__main__ import _parse_args
+
+
+def test_parse_args_no_paths_defaults() -> None:
+    args = _parse_args([])
+
+    assert args.paths == []
+    assert args.open_paths is None
+
+
+def test_parse_args_positional_paths() -> None:
+    args = _parse_args(["/tmp/foo.zip", "/tmp/bar"])
+
+    assert args.paths == ["/tmp/foo.zip", "/tmp/bar"]
+    assert args.open_paths is None
+
+
+def test_parse_args_open_flag_repeatable() -> None:
+    args = _parse_args(["--open", "/tmp/foo", "--open", "/tmp/bar"])
+
+    assert args.open_paths == ["/tmp/foo", "/tmp/bar"]
+
+
+def test_parse_args_positional_and_open_combined() -> None:
+    args = _parse_args(["/tmp/positional", "--open", "/tmp/flagged"])
+
+    assert args.paths == ["/tmp/positional"]
+    assert args.open_paths == ["/tmp/flagged"]


### PR DESCRIPTION
Lets an external tool launch Crush with one or more files/folders pre-queued (crush PATH [PATH ...] / crush --open PATH, repeatable),