### PR TITLE
fix: recognize fractional-second epoch timestamps in Value Inspector(#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Crush will be documented in this file.
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixed Value Inspector not recognizing epoch timestamps with a fractional component (e.g. `1760996870913.061`) for any arithmetic-based timestamp format (Unix s/ms/µs, Cocoa, Chrome/WebKit, Windows FILETIME, HFS+, .NET Ticks, GPS Time). Sub-second precision is now shown when present. Addresses [#51](https://github.com/kalink0/crush-forensics/issues/51), reported by [@JamesHabben](https://github.com/JamesHabben).
+- Fixed timestamp decoding (Value Inspector and the DB Table viewer's "interpret column as timestamp") relying on the OS's C library for epoch conversion, which made Windows reject valid pre-1970 timestamps that Linux/Mac decode fine — the same evidence value could show as a date on one examiner's machine and as a raw number on another's. Both now compute purely in Python.
+
 ## v0.16.0 - 2026-08-26
 
 **Focus: SQLite deleted-data recovery (Freelist Recovery, Freeblocks, Unallocated Space); Send to Peach handoff; CLI args to open evidence on startup; viewer tab management.**

--- a/crush/core/ts_decode.py
+++ b/crush/core/ts_decode.py
@@ -3,7 +3,9 @@
 """Timestamp column decoding helpers — no Qt dependency."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+
+_UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 # (internal_key, menu_label, header_suffix)
 TS_FORMATS: list[tuple[str, str, str]] = [
@@ -40,7 +42,11 @@ def decode_ts(value: int | float, fmt: str) -> str | None:
             unix = v / 1_000_000.0 - _WIN_EPOCH_OFFSET
         else:
             return None
-        dt = datetime.fromtimestamp(unix, tz=timezone.utc)
+        # epoch + timedelta rather than datetime.fromtimestamp(): the latter calls the
+        # OS's C library, which on Windows rejects negative (pre-1970) timestamps that
+        # Linux/Mac handle fine — the same evidence value would decode differently
+        # depending on the examiner's OS.
+        dt = _UNIX_EPOCH + timedelta(seconds=unix)
         return dt.strftime("%Y-%m-%d %H:%M:%S") + " UTC"
-    except (OSError, OverflowError, ValueError, TypeError):
+    except (OverflowError, ValueError, TypeError):
         return None

--- a/crush/tests/test_ts_decode.py
+++ b/crush/tests/test_ts_decode.py
@@ -57,6 +57,11 @@ class TestDecodeTsFormats:
         # A value far in the future that overflows datetime
         assert decode_ts(10**18, "unix_s") is None
 
+    def test_negative_unix_s_pre_1970(self) -> None:
+        # datetime.fromtimestamp() rejects negative values on Windows (OSError) while
+        # working fine on Linux/Mac; epoch+timedelta must decode this the same everywhere.
+        assert decode_ts(-86400, "unix_s") == "1969-12-31 00:00:00 UTC"
+
     def test_output_ends_with_utc(self) -> None:
         result = decode_ts(self._UNIX_S, "unix_s")
         assert result is not None

--- a/crush/tests/test_value_inspector.py
+++ b/crush/tests/test_value_inspector.py
@@ -248,6 +248,38 @@ class TestTimestamp:
         rows = _interpret(" ".join(f"{b:02x}" for b in data))
         assert _get(rows, "Timestamp", "Windows SYSTEMTIME") is None
 
+    # -- Fractional-value timestamps (issue #51) --------------------------------
+
+    def test_unix_ms_with_fractional_component(self) -> None:
+        # Reported case: a ms epoch with a sub-ms fraction appended ("...913.061").
+        # int(raw) rejects the "." so this must fall back to a float parse.
+        rows = _interpret("1760996870913.061")
+        ts = _value(rows, "Timestamp", "Unix (ms)")
+        assert ts == "2025-10-20 21:47:50.913061 UTC"
+
+    def test_unix_s_with_fractional_component(self) -> None:
+        rows = _interpret("1718000000.5")
+        ts = _value(rows, "Timestamp", "Unix (s)")
+        assert ts == "2024-06-10 06:13:20.500000 UTC"
+
+    def test_fractional_input_no_bitfield_formats(self) -> None:
+        # Twitter Snowflake / FAT unpack exact bit fields (shift/mask) and can't
+        # accept a float, even though the arithmetic-based formats now resolve one.
+        rows = _interpret("1760996870913.061")
+        assert _get(rows, "Timestamp", "Twitter / X Snowflake") is None
+        assert _get(rows, "Timestamp", "FAT / exFAT (MS-DOS)") is None
+
+    def test_small_fractional_no_spurious_cocoa_ns(self) -> None:
+        # Cocoa (ns)'s plausible range dips below zero (like Cocoa (s)'s), so an
+        # unguarded float fallback would match trivial values such as "123.0".
+        rows = _interpret("123.0")
+        assert _get(rows, "Timestamp", "Cocoa / Apple (ns)") is None
+
+    def test_negative_fractional_no_spurious_timestamps(self) -> None:
+        rows = _interpret("-1760996870913.061")
+        assert _get(rows, "Timestamp", "Unix (ms)") is None
+        assert _get(rows, "Timestamp", "Cocoa / Apple (ns)") is None
+
 
 # ---------------------------------------------------------------------------
 # UUID group

--- a/crush/viewers/value_inspector.py
+++ b/crush/viewers/value_inspector.py
@@ -94,14 +94,19 @@ _GPS_NS_MAX = _GPS_S_MAX * 1_000_000_000
 
 
 def _fmt_dt(dt: datetime) -> str:
+    if dt.microsecond:
+        return f"{dt.strftime('%Y-%m-%d %H:%M:%S')}.{dt.microsecond:06d} UTC"
     return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _safe_ts(ts_s: float) -> str | None:
+    # epoch + timedelta rather than datetime.fromtimestamp(): the latter is OS-clamped on
+    # Windows and rejects timestamps fromtimestamp() would otherwise handle fine on Linux/Mac.
     try:
-        return _fmt_dt(datetime.fromtimestamp(ts_s, tz=timezone.utc))
-    except (OSError, OverflowError, ValueError):
+        dt = _UNIX_EPOCH + timedelta(seconds=ts_s)
+    except (OverflowError, ValueError):
         return None
+    return _fmt_dt(dt)
 
 
 def _bcd_byte(b: int) -> int | None:
@@ -271,7 +276,12 @@ def _interpret(raw: str) -> list[_Row]:
     # -----------------------------------------------------------------------
     # Group: Timestamps
     # -----------------------------------------------------------------------
-    ts = eff_int
+    # `ts` drives the arithmetic-based formats (division/addition against an epoch) and falls
+    # back to the parsed float so a value with a fractional component (e.g. sub-ms noise
+    # appended to a ms epoch, "1760996870913.061") still resolves instead of being dropped.
+    # `ts_int` stays integer-only, for the two formats below that unpack exact bit fields.
+    ts_int = eff_int
+    ts: int | float | None = eff_int if eff_int is not None else float_val
 
     if ts is not None and _TS_S_MIN <= ts <= _TS_S_MAX:
         rows.append(R("Timestamp", "Unix (s)", _safe_ts(ts)))
@@ -288,8 +298,9 @@ def _interpret(raw: str) -> list[_Row]:
     else:
         rows.append(R("Timestamp", "Unix (µs)", None))
 
-    # Cocoa: seconds since 2001-01-01; for floats require > 1M to avoid false positives on tiny values
-    cocoa_src = ts if ts is not None else (float_val if float_val is not None and float_val > 1_000_000 else None)
+    # Cocoa: seconds since 2001-01-01; for floats require > 1M to avoid false positives on
+    # tiny values (Cocoa's plausible range dips below zero, unlike the other formats).
+    cocoa_src = ts if eff_int is not None else (float_val if float_val is not None and float_val > 1_000_000 else None)
     if cocoa_src is not None and _COCOA_MIN <= cocoa_src <= _COCOA_MAX:
         try:
             rows.append(R("Timestamp", "Cocoa / Apple (s)", _fmt_dt(_COCOA_EPOCH + timedelta(seconds=cocoa_src))))
@@ -298,10 +309,12 @@ def _interpret(raw: str) -> list[_Row]:
     else:
         rows.append(R("Timestamp", "Cocoa / Apple (s)", None))
 
-    # Cocoa nanoseconds: ns since 2001-01-01
-    if ts is not None and _COCOA_NS_MIN <= ts <= _COCOA_NS_MAX:
+    # Cocoa nanoseconds: ns since 2001-01-01; same float-magnitude guard as Cocoa (s) above —
+    # _COCOA_NS_MIN is deep negative, so an unguarded float fallback would match trivial values.
+    cocoa_ns_src = ts if eff_int is not None else (float_val if float_val is not None and float_val > 1_000_000 else None)
+    if cocoa_ns_src is not None and _COCOA_NS_MIN <= cocoa_ns_src <= _COCOA_NS_MAX:
         try:
-            dt = _COCOA_EPOCH + timedelta(seconds=ts / 1_000_000_000)
+            dt = _COCOA_EPOCH + timedelta(seconds=cocoa_ns_src / 1_000_000_000)
             rows.append(R("Timestamp", "Cocoa / Apple (ns)", _fmt_dt(dt)))
         except (OverflowError, ValueError):
             rows.append(R("Timestamp", "Cocoa / Apple (ns)", None))
@@ -355,9 +368,9 @@ def _interpret(raw: str) -> list[_Row]:
     else:
         rows.append(R("Timestamp", "OLE Automation Date", None))
 
-    # Twitter / X Snowflake ID: upper 41 bits = ms since Twitter epoch
-    if ts is not None and ts >= (1 << 22):  # timestamp part must be > 0
-        tw_ms = (ts >> 22) + _TWITTER_EPOCH_MS
+    # Twitter / X Snowflake ID: upper 41 bits = ms since Twitter epoch (bit-packed, integer-only)
+    if ts_int is not None and ts_int >= (1 << 22):  # timestamp part must be > 0
+        tw_ms = (ts_int >> 22) + _TWITTER_EPOCH_MS
         if _TS_MS_MIN <= tw_ms <= _TS_MS_MAX:
             rows.append(R("Timestamp", "Twitter / X Snowflake", _safe_ts(tw_ms / 1000.0)))
         else:
@@ -366,9 +379,9 @@ def _interpret(raw: str) -> list[_Row]:
         rows.append(R("Timestamp", "Twitter / X Snowflake", None))
 
     # FAT / exFAT (MS-DOS): 32-bit packed date+time, 2-second resolution, epoch 1980-01-01
-    if ts is not None and _FAT_TS_MIN <= ts <= _FAT_TS_MAX:
-        date_word = (ts >> 16) & 0xFFFF
-        time_word = ts & 0xFFFF
+    if ts_int is not None and _FAT_TS_MIN <= ts_int <= _FAT_TS_MAX:
+        date_word = (ts_int >> 16) & 0xFFFF
+        time_word = ts_int & 0xFFFF
         fat_year  = ((date_word >> 9) & 0x7F) + 1980
         fat_month = (date_word >> 5) & 0x0F
         fat_day   = date_word & 0x1F


### PR DESCRIPTION
closes #51 