### PR TITLE
fix: ABX parser silently dropped data on multi-root files and rare to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Crush will be documented in this file.
 ### New Features
 
 - Realm parser now extracts row/table data for pre-Cluster (file format <10) databases, not just class names — covers every old column type, including Mixed, Subtables, StringEnum, and Link/LinkList, validated against real sample files. Continues [#55](https://github.com/kalink0/crush-forensics/issues/55), reported by [@abrignoni](https://github.com/abrignoni).
+- ABX Viewer's reconstructed XML pane now uses the same viewer as generic XML files, adding a Ctrl+F search bar (regex/case options, hit navigation) and pretty-printed, indented output instead of one unbroken line.
 
 ### Bug Fixes
 
@@ -14,6 +15,8 @@ All notable changes to Crush will be documented in this file.
 - Fixed the Realm parser decoding 1-bit-wide Int columns as `True`/`False` instead of their real integer value — array storage width depends on the largest value an array ever held, not the column's declared type. Found by [@abrignoni](https://github.com/abrignoni) on a real-world file.
 - Fixed the Realm parser silently returning an empty schema for files in Realm's "streaming form" (e.g. `Group::write()` output, or a Realm Studio export) instead of resolving the real top reference from the file's end-of-file footer.
 - Fixed the Realm parser leaving row/table decode failures unexplained — the Properties panel's "Row data" field now states the parser's own specific diagnosis instead of a generic or missing message.
+- Fixed ABX files with more than one top-level element (e.g. `settings_secure.xml`) failing to build a tree view — these are now wrapped in a synthetic root instead of raising an XML syntax error.
+- Fixed the ABX decoder silently dropping unsupported XML tokens and truncating the rest of the file on any decode error with no indication of scope, and raw XML-illegal control characters (a known real-world occurrence in `settings_secure.xml` values) breaking the reconstruction entirely — all three now produce explicit, visible warnings instead of silent or total data loss.
 
 ## v0.17.0 - 2026-08-31
 

--- a/crush/docs/format-support.md
+++ b/crush/docs/format-support.md
@@ -58,9 +58,12 @@ Limitations
 
 ### Android Binary XML (ABX)
 - Decodes ABX v1/v2 into a structured tree and reconstructed XML (ABX Viewer).
+- Files with more than one top-level element and no enclosing root (e.g. `settings_secure.xml`) are wrapped in a synthetic `<abx-root>` so they still parse into a tree, instead of failing on "extra content" errors.
+- Raw XML-illegal control characters in decoded values (occasionally present in real `settings_secure.xml` data) are re-encoded visibly (`\xHH`) rather than breaking reconstruction or being silently dropped.
 
 Limitations
 - Best-effort decode; newer ABX variants may not parse.
+- `ENTITY_REF`/`PROCESSING_INSTRUCTION`/`DOCDECL` tokens are not known to be emitted by Android's serializer; if encountered they are shown as a comment with a warning rather than reconstructed to exact original syntax.
 
 ### SEGB (Biome)
 - Parses SEGB v1/v2 records into the Table Viewer.
@@ -210,6 +213,7 @@ Limitations
 
 ### ABX Viewer
 - Split view with parsed tree and reconstructed XML.
+- The XML pane is pretty-printed (indented, multi-line) and includes a Ctrl+F search bar (regex/case options, hit navigation) shared with the generic Text/XML viewer.
 
 Limitations
 - XML reconstruction is best-effort.

--- a/crush/docs/handbook.md
+++ b/crush/docs/handbook.md
@@ -468,7 +468,7 @@ iOS apps sometimes store Protobuf bytes as a `<data>` field inside an NSKeyedArc
 
 ### ABX Viewer
 
-Decodes Android Binary XML (ABX) format used in Android system and app settings directories.
+Decodes Android Binary XML (ABX) format used in Android system and app settings directories. The reconstructed-XML pane is pretty-printed and has a Ctrl+F search bar (regex/case options, hit navigation). Files with multiple top-level elements and no enclosing root (e.g. `settings_secure.xml`) are wrapped in a synthetic `<abx-root>` so they still resolve to a tree.
 
 ### SEGB / Biome Viewer
 

--- a/crush/parsers/abx_decoder.py
+++ b/crush/parsers/abx_decoder.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import re
 import struct
 from dataclasses import dataclass
 
@@ -58,9 +59,12 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
     out: list[str] = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"]
     tag_stack: list[str] = []
     open_tag = False
+    root_element_count = 0
+    token_start_pos = reader.pos
 
     try:
         while reader.pos < len(data):
+            token_start_pos = reader.pos
             token_byte = reader.read_u8()
             token = token_byte & 0x0F
             dtype = token_byte & 0xF0
@@ -73,11 +77,14 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
             if token == START_TAG:
                 if open_tag:
                     out.append(">")
+                    open_tag = False
+                if not tag_stack:
+                    root_element_count += 1
                 name = _to_string(reader.read_value(dtype))
                 if not name:
                     name = "unknown"
                     warnings.append("Empty start tag name")
-                out.append(f"<{_xml_escape(name)}")
+                out.append(f"<{_xml_escape(name, warnings)}")
                 open_tag = True
                 tag_stack.append(name)
 
@@ -92,7 +99,7 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
                     attr_val = reader.read_value(attr_type)
                     attr_val_str = _to_string(attr_val)
                     out.append(
-                        f" {_xml_escape(attr_name)}=\"{_xml_escape(attr_val_str)}\""
+                        f' {_xml_escape(attr_name, warnings)}="{_xml_escape(attr_val_str, warnings)}"'
                     )
                 continue
 
@@ -108,7 +115,7 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
                     open_tag = False
                 if tag_stack:
                     tag_stack.pop()
-                out.append(f"</{_xml_escape(name)}>")
+                out.append(f"</{_xml_escape(name, warnings)}>")
                 continue
 
             if token == TEXT:
@@ -116,7 +123,7 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
                 if open_tag:
                     out.append(">")
                     open_tag = False
-                out.append(_xml_escape(text))
+                out.append(_xml_escape(text, warnings))
                 continue
 
             if token == CDSECT:
@@ -124,7 +131,7 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
                 if open_tag:
                     out.append(">")
                     open_tag = False
-                out.append(f"<![CDATA[{text}]]>")
+                out.append(f"<![CDATA[{_sanitize_control_chars(text, warnings)}]]>")
                 continue
 
             if token == COMMENT:
@@ -132,12 +139,33 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
                 if open_tag:
                     out.append(">")
                     open_tag = False
-                out.append(f"<!--{_xml_escape(text)}-->")
+                out.append(f"<!--{_xml_escape(text, warnings)}-->")
                 continue
 
-            if token in (ENTITY_REF, IGNORABLE_WHITESPACE, PROCESSING_INSTRUCTION, DOCDECL):
-                # Best-effort: consume value if any, then skip
+            if token == IGNORABLE_WHITESPACE:
+                # Per XmlPullParser semantics this is formatting whitespace
+                # between structural elements — safe to discard, matches how
+                # any XML serializer would treat it. Not a data loss.
                 _ = reader.read_value(dtype)
+                continue
+
+            if token in (ENTITY_REF, PROCESSING_INSTRUCTION, DOCDECL):
+                # These carry semantic content unlike IGNORABLE_WHITESPACE.
+                # Android's BinaryXmlSerializer is not known to emit them, so
+                # we don't guess at exact re-encoded syntax (would be a
+                # heuristic) — surface the raw value visibly instead of
+                # silently dropping it, and flag it so it gets a second look.
+                token_name = {
+                    ENTITY_REF: "ENTITY_REF",
+                    PROCESSING_INSTRUCTION: "PROCESSING_INSTRUCTION",
+                    DOCDECL: "DOCDECL",
+                }[token]
+                value = _to_string(reader.read_value(dtype))
+                warnings.append(f"Unsupported {token_name} token encountered (rare/unverified format)")
+                if open_tag:
+                    out.append(">")
+                    open_tag = False
+                out.append(f"<!--{token_name}: {_xml_escape(value, warnings)}-->")
                 continue
 
             if token == ATTRIBUTE:
@@ -153,7 +181,27 @@ def decode_abx(data: bytes) -> AbxDecodeResult:
         if open_tag:
             out.append(">")
     except Exception as exc:
-        warnings.append(f"Decode error: {exc}")
+        remaining = len(data) - token_start_pos
+        warnings.insert(
+            0,
+            f"TRUNCATED: decode error at offset {token_start_pos} (0x{token_start_pos:x}): "
+            f"{exc} — {remaining} of {len(data)} bytes not decoded",
+        )
+        if open_tag:
+            out.append(">")
+            open_tag = False
+        out.append(
+            f"<!--ABX-DECODE-TRUNCATED at offset {token_start_pos}: "
+            f"{remaining} bytes not decoded ({_xml_escape(str(exc), warnings)})-->"
+        )
+
+    if root_element_count > 1:
+        warnings.append(
+            f"Multiple root elements ({root_element_count}) found; wrapped in "
+            f"synthetic <abx-root> for well-formed XML"
+        )
+        out.insert(1, "<abx-root>")
+        out.append("</abx-root>")
 
     return AbxDecodeResult("".join(out), warnings)
 
@@ -266,14 +314,34 @@ def _to_string(value: object | None) -> str:
     return str(value)
 
 
-def _xml_escape(text: str) -> str:
-    return (
+def _xml_escape(text: str, warnings: list[str] | None = None) -> str:
+    escaped = (
         text.replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
         .replace("\"", "&quot;")
         .replace("'", "&apos;")
     )
+    return _sanitize_control_chars(escaped, warnings)
+
+
+# XML 1.0 only permits #x9 | #xA | #xD | [#x20-...]; raw control bytes below
+# that (as can occur in real-world settings_secure.xml values) break any
+# downstream well-formed-XML parse. Rather than silently stripping forensic
+# byte content, re-encode each one visibly so it survives the round-trip.
+_INVALID_XML_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _sanitize_control_chars(text: str, warnings: list[str] | None = None) -> str:
+    if not _INVALID_XML_CHARS.search(text):
+        return text
+    control_char_warning = (
+        "Raw XML-illegal control character(s) found in decoded value(s); "
+        "re-encoded as \\xHH to keep the XML well-formed"
+    )
+    if warnings is not None and control_char_warning not in warnings:
+        warnings.append(control_char_warning)
+    return _INVALID_XML_CHARS.sub(lambda m: f"\\x{ord(m.group(0)):02x}", text)
 
 
 def _decode_modified_utf8(data: bytes) -> str:

--- a/crush/parsers/abx_parser.py
+++ b/crush/parsers/abx_parser.py
@@ -28,8 +28,15 @@ class AbxParser(AbstractParser):
         try:
             decoded = decode_abx(raw)
             xml_str = decoded.xml
+            display_xml_str = xml_str
             try:
-                tree = _xml_to_tree(xml_str)
+                root = _parse_xml(xml_str)
+                tree = _element_to_dict(root)
+                # decode_abx emits one continuous line with no whitespace
+                # between elements; re-indent for the "Reconstructed XML"
+                # pane so it wraps into readable lines instead of one very
+                # long unbroken one.
+                display_xml_str = _pretty_print(root, fallback=xml_str)
             except Exception as exc:
                 tree = {
                     "error": str(exc),
@@ -40,12 +47,17 @@ class AbxParser(AbstractParser):
                 "File size": f"{node.size:,} B",
             }
             if decoded.warnings:
-                meta["Warnings"] = "; ".join(decoded.warnings[:3])
+                shown = decoded.warnings[:3]
+                remaining = len(decoded.warnings) - len(shown)
+                summary = "; ".join(shown)
+                if remaining > 0:
+                    summary += f" (+{remaining} more)"
+                meta["Warnings"] = summary
             return ParseResult(
                 viewer_type="abx",
-                data={"tree": tree, "xml_str": xml_str},
+                data={"tree": tree, "xml_str": display_xml_str},
                 metadata=meta,
-                text_index=xml_str[:4000],
+                text_index=display_xml_str[:4000],
             )
         except Exception as exc:
             # Fallback: show error in tree viewer
@@ -56,12 +68,23 @@ class AbxParser(AbstractParser):
             )
 
 
-def _xml_to_tree(xml_str: str) -> dict[str, Any]:
-    """Convert XML string to nested dict for the tree viewer."""
+def _parse_xml(xml_str: str) -> Any:
     from lxml import etree
 
-    root = etree.fromstring(xml_str.encode("utf-8", errors="replace"))
-    return _element_to_dict(root)
+    return etree.fromstring(xml_str.encode("utf-8", errors="replace"))
+
+
+def _pretty_print(root: Any, fallback: str) -> str:
+    from lxml import etree
+
+    try:
+        # lxml refuses xml_declaration=True with encoding="unicode", so
+        # serialize to utf-8 bytes (gets the real declaration) and decode.
+        return etree.tostring(
+            root, pretty_print=True, xml_declaration=True, encoding="utf-8"
+        ).decode("utf-8")
+    except Exception:
+        return fallback
 
 
 def _element_to_dict(el: Any) -> dict[str, Any]:

--- a/crush/tests/test_parsers.py
+++ b/crush/tests/test_parsers.py
@@ -1717,6 +1717,93 @@ def test_abx_decode_invalid_string_pool_reference_reports_error() -> None:
     assert any("Invalid ABX string pool reference" in w for w in result.warnings)
 
 
+def test_abx_decode_multi_root_wraps_synthetic_root() -> None:
+    # Real-world Android files (e.g. settings_secure.xml) can contain more
+    # than one top-level element with no enclosing root — without wrapping,
+    # the downstream lxml parse in AbxParser fails with "Extra content at
+    # the end of the document" and the whole tree view is lost.
+    magic = b"ABX\x00"
+    start_doc = bytes([0x00])
+    tag_a = bytes([0x22]) + _utf("a")
+    end_a = bytes([0x23]) + _utf("a")
+    tag_b = bytes([0x22]) + _utf("b")
+    end_b = bytes([0x23]) + _utf("b")
+    data = magic + start_doc + tag_a + end_a + tag_b + end_b
+
+    result = decode_abx(data)
+
+    assert any("Multiple root elements" in w for w in result.warnings)
+
+    from lxml import etree
+
+    root = etree.fromstring(result.xml.encode("utf-8"))  # must not raise
+    assert root.tag == "abx-root"
+    assert [c.tag for c in root] == ["a", "b"]
+
+
+def test_abx_decode_sanitizes_illegal_control_chars() -> None:
+    # XML 1.0 forbids raw control bytes below 0x20 (other than tab/LF/CR).
+    # Silently stripping them would lose forensic byte content; silently
+    # passing them through breaks the downstream XML parse entirely.
+    magic = b"ABX\x00"
+    start_doc = bytes([0x00])
+    start_tag = bytes([0x22]) + _utf("root")
+    attr = bytes([0x2F]) + _interned("val") + _utf("bad\x01char")
+    end_tag = bytes([0x23]) + _utf("root")
+    data = magic + start_doc + start_tag + attr + end_tag
+
+    result = decode_abx(data)
+
+    assert "\\x01" in result.xml
+    assert "\x01" not in result.xml
+    assert any("illegal control character" in w.lower() for w in result.warnings)
+
+    from lxml import etree
+
+    etree.fromstring(result.xml.encode("utf-8"))  # must not raise
+
+
+def test_abx_decode_surfaces_processing_instruction_not_silently() -> None:
+    # ENTITY_REF/PROCESSING_INSTRUCTION/DOCDECL used to be consumed and
+    # discarded with zero warning — a silent data loss. They must now show
+    # up in the output and be flagged.
+    magic = b"ABX\x00"
+    start_doc = bytes([0x00])
+    start_tag = bytes([0x22]) + _utf("root")
+    pi = bytes([0x28]) + _utf("mypi data")  # token=PROCESSING_INSTRUCTION(8), dtype=TYPE_STRING
+    end_tag = bytes([0x23]) + _utf("root")
+    data = magic + start_doc + start_tag + pi + end_tag
+
+    result = decode_abx(data)
+
+    assert "mypi data" in result.xml
+    assert any("PROCESSING_INSTRUCTION" in w for w in result.warnings)
+
+
+def test_abx_decode_reports_truncation_scope_on_error() -> None:
+    # A single decode error used to silently drop every remaining byte with
+    # only a generic, scope-free message. The warning and the XML itself
+    # must now make clear how much was lost and from where.
+    magic = b"ABX\x00"
+    start_doc = bytes([0x00])
+    start_tag = bytes([0x22]) + _utf("root")
+    bad_start_tag = bytes([0xE2])  # unassigned dtype, raises mid-document
+    tail = b"\x00" * 10
+    data = magic + start_doc + start_tag + bad_start_tag + tail
+    expected_offset = len(magic) + len(start_doc) + len(start_tag)
+    expected_remaining = len(data) - expected_offset
+
+    result = decode_abx(data)
+
+    assert any(
+        w.startswith("TRUNCATED:")
+        and f"offset {expected_offset}" in w
+        and f"{expected_remaining} of {len(data)} bytes not decoded" in w
+        for w in result.warnings
+    )
+    assert "ABX-DECODE-TRUNCATED" in result.xml
+
+
 def test_abx_parser_parse(tmp_path: Path) -> None:
     abx_path = tmp_path / "binary.xml"
     abx_path.write_bytes(_make_abx_bytes())

--- a/crush/viewers/abx_viewer.py
+++ b/crush/viewers/abx_viewer.py
@@ -14,17 +14,14 @@ The data dict passed in has the shape:
 from __future__ import annotations
 
 from PySide6.QtCore import Qt
-import re
-
-from PySide6.QtGui import QFont, QColor, QSyntaxHighlighter, QTextCharFormat, QTextOption
 from PySide6.QtWidgets import (
     QLabel,
-    QPlainTextEdit,
     QSplitter,
     QVBoxLayout,
     QWidget,
 )
 
+from crush.viewers.text_viewer import TextView
 from crush.viewers.tree_viewer import TreeViewer
 
 
@@ -72,48 +69,13 @@ class AbxViewer(QWidget):
         )
         right_layout.addWidget(right_header)
 
-        xml_editor = QPlainTextEdit()
-        xml_editor.setReadOnly(True)
-        # setReadOnly() only grants mouse-based selection in Qt6 — keyboard
-        # cursor movement and Shift-selection need TextSelectableByKeyboard too.
-        xml_editor.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-            | Qt.TextInteractionFlag.TextSelectableByKeyboard
-        )
-        # Visual wrap to avoid horizontal scrolling; no actual line breaks inserted.
-        xml_editor.setLineWrapMode(QPlainTextEdit.LineWrapMode.WidgetWidth)
-        xml_editor.setWordWrapMode(QTextOption.WrapMode.WordWrap)
-        xml_editor.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        font = QFont("Courier New", 10)
-        font.setStyleHint(QFont.StyleHint.Monospace)
-        xml_editor.setFont(font)
-        _XmlHighlighter(xml_editor.document())
-        xml_editor.setPlainText(data.get("xml_str", ""))
-        right_layout.addWidget(xml_editor)
+        # TextView brings its own XML syntax highlighting (auto-detected from
+        # the leading "<?xml") plus a Ctrl+F search bar with regex/case
+        # options and hit navigation — no need to duplicate either here.
+        xml_view = TextView(data.get("xml_str", ""), right)
+        right_layout.addWidget(xml_view)
 
         splitter.addWidget(right)
         splitter.setSizes([400, 400])
 
         layout.addWidget(splitter)
-
-
-class _XmlHighlighter(QSyntaxHighlighter):
-    def __init__(self, document: object) -> None:
-        super().__init__(document)  # type: ignore[arg-type]
-        self._fmt_tag = QTextCharFormat()
-        self._fmt_tag.setForeground(QColor("#005a9c"))
-        self._fmt_attr = QTextCharFormat()
-        self._fmt_attr.setForeground(QColor("#7a3e9d"))
-        self._fmt_attr_value = QTextCharFormat()
-        self._fmt_attr_value.setForeground(QColor("#2a7b2e"))
-        self._tag_re = re.compile(r"</?\s*[^>\s/]+")
-        self._attr_re = re.compile(r"\s+([A-Za-z_:\-][\w:.-]*)\s*=")
-        self._attr_value_re = re.compile(r"=\s*\"([^\"\\]|\\.)*\"")
-
-    def highlightBlock(self, text: str) -> None:  # type: ignore[override]
-        for m in self._tag_re.finditer(text):
-            self.setFormat(m.start(), m.end() - m.start(), self._fmt_tag)
-        for m in self._attr_re.finditer(text):
-            self.setFormat(m.start(1), m.end(1) - m.start(1), self._fmt_attr)
-        for m in self._attr_value_re.finditer(text):
-            self.setFormat(m.start(), m.end() - m.start(), self._fmt_attr_value)


### PR DESCRIPTION
…kens

Files with multiple top-level elements (e.g. settings_secure.xml) failed the downstream XML parse entirely; they're now wrapped in a synthetic <abx-root>. ENTITY_REF/PROCESSING_INSTRUCTION/DOCDECL tokens and any decode-abort were previously silent or scope-free; both now produce explicit warnings, and raw XML-illegal control characters in decoded values are re-encoded visibly instead of breaking reconstruction. The ABX viewer's XML pane now reuses TextView for search (Ctrl+F) and pretty-printed output instead of one unbroken line.