### PR TITLE
fix: sort numeric-looking columns by value, not as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Crush will be documented in this file.
 
 ### Bug Fixes
 
+- Fixed the LevelDB viewer's Records table sorting the Seq column as text instead of numerically (`1, 10, 100, 2, 20…`) — the table's filter proxy has its own independent sort role, separate from the underlying model's, that was never set to match. Addresses [#61](https://github.com/kalink0/crush-forensics/issues/61), reported by [@JamesHabben](https://github.com/JamesHabben).
+- Fixed Multi-Log Studio's PID column sorting the same way (text, not numeric) — found while auditing the codebase for the same bug class as [#61](https://github.com/kalink0/crush-forensics/issues/61).
 - Fixed the Protobuf parser discarding a length-delimited field's payload past its 64-byte display preview instead of retaining the full bytes — meant a string/bytes/submessage field longer than that was silently missing data from the newly added value box and "Inspect BLOB…" action. Found while implementing [#60](https://github.com/kalink0/crush-forensics/issues/60).
 - Fixed the Realm parser silently returning zero classes on file-format-9 (and older) databases, indistinguishable from a genuinely empty file — the class-name array uses a different on-disk form pre-format-10 that the parser didn't decode. Addresses [#55](https://github.com/kalink0/crush-forensics/issues/55), reported by [@abrignoni](https://github.com/abrignoni).
 - Fixed the Realm parser decoding 1-bit-wide Int columns as `True`/`False` instead of their real integer value — array storage width depends on the largest value an array ever held, not the column's declared type. Found by [@abrignoni](https://github.com/abrignoni) on a real-world file.

--- a/crush/tests/test_leveldb_viewer.py
+++ b/crush/tests/test_leveldb_viewer.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Tests for the LevelDB viewer's Records table sorting."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QStandardItemModel
+
+from crush.viewers.leveldb_viewer import _COLUMNS, _StateFilterProxy, _make_item
+
+
+def test_seq_column_sorts_numerically_not_as_text(qapp) -> None:
+    """Regression test for #61: QSortFilterProxyModel has its own independent
+    sortRole (default DisplayRole), separate from the source model's — setting
+    only the source model's sortRole doesn't propagate to it, so the Records
+    table's Seq column previously sorted "1", "10", "100", "2", "20" as text
+    instead of by numeric value."""
+    model = QStandardItemModel(0, len(_COLUMNS))
+    model.setHorizontalHeaderLabels(_COLUMNS)
+    model.setSortRole(Qt.ItemDataRole.UserRole)
+
+    for seq in (1, 10, 100, 2, 20):
+        row = [_make_item(str(seq), seq)] + [_make_item("") for _ in range(len(_COLUMNS) - 1)]
+        model.appendRow(row)
+
+    proxy = _StateFilterProxy()
+    proxy.setSourceModel(model)
+    proxy.setSortRole(Qt.ItemDataRole.UserRole)
+    proxy.sort(0, Qt.SortOrder.AscendingOrder)
+
+    result = [proxy.index(r, 0).data() for r in range(proxy.rowCount())]
+    assert result == ["1", "2", "10", "20", "100"]

--- a/crush/tests/test_log_db.py
+++ b/crush/tests/test_log_db.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Tests for the Multi-Log Studio backing SQLite database."""
+from __future__ import annotations
+
+from crush.core.log_db import LogDatabase
+from crush.viewers.multi_log_viewer import _COL_PID, _SQL_SORT_COL
+
+
+def test_pid_sort_column_is_numeric_cast() -> None:
+    """Regression test companion for #61: pid is stored as TEXT (log_db._SCHEMA),
+    so a plain `ORDER BY pid` sorts "1", "10", "100", "2", "20" as text instead of
+    by numeric value — the sort column must be wrapped in CAST(... AS INTEGER)."""
+    assert _SQL_SORT_COL[_COL_PID] == "CAST(pid AS INTEGER)"
+
+
+def test_pid_orders_numerically_not_as_text() -> None:
+    db = LogDatabase()
+    try:
+        db.insert_batch(1, [
+            {"pid": pid, "message": f"m{pid}"} for pid in ("1", "10", "100", "2", "20")
+        ])
+        con = LogDatabase.open_worker_connection(db.path)
+        try:
+            order_col = _SQL_SORT_COL[_COL_PID]
+            rows = con.execute(f"SELECT pid FROM entries ORDER BY {order_col} ASC").fetchall()  # noqa: S608
+        finally:
+            con.close()
+        assert [r[0] for r in rows] == ["1", "2", "10", "20", "100"]
+    finally:
+        db.close()

--- a/crush/viewers/leveldb_viewer.py
+++ b/crush/viewers/leveldb_viewer.py
@@ -171,6 +171,10 @@ class LevelDbRecordsWidget(QWidget):
 
         self._proxy = _StateFilterProxy()
         self._proxy.setSourceModel(self._model)
+        # QSortFilterProxyModel has its own independent sortRole (defaults to
+        # DisplayRole) — setting it only on the source model above doesn't propagate
+        # here, so the table would sort Seq/Offset as text without this.
+        self._proxy.setSortRole(Qt.ItemDataRole.UserRole)
 
         self._table = QTableView()
         self._table.setModel(self._proxy)

--- a/crush/viewers/multi_log_viewer.py
+++ b/crush/viewers/multi_log_viewer.py
@@ -797,7 +797,9 @@ _SQL_SORT_COL: dict[int, str] = {
     _COL_TS:   "ts_unix",
     _COL_LVL:  "level",
     _COL_PROC: "process",
-    _COL_PID:  "pid",
+    # pid is stored as TEXT (crush/core/log_db.py) — CAST to sort numerically
+    # ("2" before "10") instead of SQLite's default TEXT collation order.
+    _COL_PID:  "CAST(pid AS INTEGER)",
     _COL_SUB:  "subsystem",
     _COL_CAT:  "category",
     _COL_MSG:  "message",


### PR DESCRIPTION
LevelDB viewer's Records table sorted Seq as text ("1, 10, 100, 2, 20…") because the QSortFilterProxyModel used for filtering has its own independent sortRole, separate from the source model's — setting only the source model's role never propagated to it. Also fixes the same bug class in Multi-Log Studio's PID column, found while auditing for it (PID is stored as TEXT, so ORDER BY pid sorted lexicographically).
fixes #61 