### PR TITLE
feat: add search and expand/collapse to the protobuf viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Crush will be documented in this file.
 - ABX Viewer's reconstructed XML pane now uses the same viewer as generic XML files, adding a Ctrl+F search bar (regex/case options, hit navigation) and pretty-printed, indented output instead of one unbroken line.
 - Value Inspector now shows a Data Size interpretation, treating the parsed value as a byte count and auto-scaling it to both decimal (KB/MB/GB…) and binary (KiB/MiB/GiB…) units. Addresses [#59](https://github.com/kalink0/crush-forensics/issues/59), reported by [@JamesHabben](https://github.com/JamesHabben).
 - Protobuf Viewer's schema-less decode tree now has a selected-value box showing the full value below the tree, and a right-click menu (Copy key / Copy value / Copy key = value / Inspect BLOB…) — matching the other tree-based viewers. Addresses [#60](https://github.com/kalink0/crush-forensics/issues/60), reported by [@JamesHabben](https://github.com/JamesHabben).
+- Protobuf Viewer's schema-less decode tree now has Expand All / Collapse All buttons and a search box that filters to matching field names/values — matching the other tree-based viewers, and matching against each field's full value even when the tree cell shows it truncated. Addresses [#63](https://github.com/kalink0/crush-forensics/issues/63).
 
 ### Bug Fixes
 

--- a/crush/tests/test_protobuf_viewer.py
+++ b/crush/tests/test_protobuf_viewer.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Tests for the Protobuf viewer's schema-less tree search/filter (#63)."""
+from __future__ import annotations
+
+from crush.parsers.protobuf_parser import _decode_message
+from crush.viewers.protobuf_viewer import ProtobufTreeWidget
+
+
+def _varint(n: int) -> bytes:
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            break
+    return bytes(out)
+
+
+def _visible_field_labels(widget: ProtobufTreeWidget) -> list[str]:
+    model = widget._model
+    root = model.invisibleRootItem()
+    labels = []
+    for row in range(root.rowCount()):
+        if not widget._tree.isRowHidden(row, model.indexFromItem(root)):
+            labels.append(root.child(row, 0).text())
+    return labels
+
+
+def test_filter_matches_field_value_text(qapp) -> None:
+    # field 1: varint 42, field 2: string "hello world"
+    raw = b"\x08\x2a" + b"\x12" + _varint(11) + b"hello world"
+    decoded, warning, _ = _decode_message(raw)
+    assert not warning
+
+    widget = ProtobufTreeWidget(decoded)
+    assert _visible_field_labels(widget) == ["field 1", "field 2"]
+
+    widget._apply_filter("hello")
+    assert _visible_field_labels(widget) == ["field 2"]
+
+    widget._apply_filter("")
+    assert _visible_field_labels(widget) == ["field 1", "field 2"]
+
+
+def test_filter_matches_field_name(qapp) -> None:
+    raw = b"\x08\x2a" + b"\x12" + _varint(11) + b"hello world"
+    decoded, warning, _ = _decode_message(raw)
+    assert not warning
+
+    widget = ProtobufTreeWidget(decoded)
+    widget._apply_filter("field 1")
+    assert _visible_field_labels(widget) == ["field 1"]
+
+
+def test_filter_matches_full_untruncated_value_past_display_cap(qapp) -> None:
+    """A field's tree-cell label truncates a large bytes value at 64 bytes with '…'
+    (see #60) — the search must still find text that only exists past that cutoff,
+    since it matches against the full value, not the truncated display label."""
+    payload = bytes(range(256)) * 2  # 512 bytes, non-utf8, well past the 64-byte cap
+    raw = b"\x0a" + _varint(len(payload)) + payload  # field 1, length-delimited bytes
+    decoded, warning, _ = _decode_message(raw)
+    assert not warning
+
+    widget = ProtobufTreeWidget(decoded)
+    # Byte value 200 (hex "c8") only appears past offset 200 in the payload — well
+    # beyond the 64-byte preview cap.
+    needle = payload[200:202].hex(" ")
+    widget._apply_filter(needle)
+    assert _visible_field_labels(widget) == ["field 1"]
+
+
+def test_filter_reveals_ancestor_when_nested_child_matches(qapp) -> None:
+    # field 2: nested message containing field 5 = string "needle_zzz"; field 1 is an
+    # unrelated varint that doesn't contain the search text anywhere.
+    inner = bytes([0x2a]) + _varint(10) + b"needle_zzz"  # field 5, length-delimited string
+    outer = b"\x08\x2a" + b"\x12" + _varint(len(inner)) + inner  # field1 varint42, field2 message
+    decoded, warning, _ = _decode_message(outer)
+    assert not warning
+
+    widget = ProtobufTreeWidget(decoded)
+    widget._apply_filter("needle_zzz")
+    # field 2 itself doesn't contain the needle in its own label ("{ 1 field(s) }") but
+    # must stay visible because its nested child field 5 matches.
+    assert _visible_field_labels(widget) == ["field 2"]
+
+    widget._apply_filter("nonexistent-needle")
+    assert _visible_field_labels(widget) == []
+
+    widget._apply_filter("")
+    assert set(_visible_field_labels(widget)) == {"field 1", "field 2"}

--- a/crush/viewers/protobuf_viewer.py
+++ b/crush/viewers/protobuf_viewer.py
@@ -182,6 +182,7 @@ _GRAY = QColor(130, 130, 130)
 _INTERP_FONT_SIZE_DELTA = -1  # points smaller than parent
 _RAW_ROLE = Qt.ItemDataRole.UserRole
 _FULLTEXT_ROLE = Qt.ItemDataRole.UserRole + 1
+_ENTRY_ROLE = Qt.ItemDataRole.UserRole + 2  # the field's original decoded entry dict
 
 
 class ProtobufTreeWidget(QWidget):
@@ -194,8 +195,31 @@ class ProtobufTreeWidget(QWidget):
 
     def __init__(self, decoded: dict[str, Any], parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._decoded = decoded
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        toolbar = QWidget()
+        toolbar.setFixedHeight(36)
+        tb_layout = QHBoxLayout(toolbar)
+        tb_layout.setContentsMargins(8, 4, 8, 4)
+        tb_layout.setSpacing(8)
+        self._expand_all_btn = QPushButton("Expand All")
+        self._expand_all_btn.clicked.connect(self._tree_expand_all)
+        tb_layout.addWidget(self._expand_all_btn)
+        self._collapse_all_btn = QPushButton("Collapse All")
+        self._collapse_all_btn.clicked.connect(self._tree_collapse_all)
+        tb_layout.addWidget(self._collapse_all_btn)
+        tb_layout.addStretch()
+        tb_layout.addWidget(QLabel("Search:"))
+        self._search = QLineEdit()
+        self._search.setPlaceholderText("Filter fields / values…")
+        self._search.setClearButtonEnabled(True)
+        self._search.setFixedWidth(200)
+        self._search.textChanged.connect(self._apply_filter)
+        tb_layout.addWidget(self._search)
+        layout.addWidget(toolbar)
 
         self._model = QStandardItemModel()
         self._model.setHorizontalHeaderLabels(["Field", "Value", "Wire type"])
@@ -261,6 +285,7 @@ class ProtobufTreeWidget(QWidget):
             wt_item = QStandardItem(wire_type)
             val_item.setData(raw_bytes, _RAW_ROLE)
             val_item.setData(full_text, _FULLTEXT_ROLE)
+            field_item.setData(entry, _ENTRY_ROLE)
             for item in (field_item, val_item, wt_item):
                 item.setEditable(False)
             parent.appendRow([field_item, val_item, wt_item])
@@ -291,6 +316,39 @@ class ProtobufTreeWidget(QWidget):
             # Recurse into nested messages
             if isinstance(val, dict) and val.get("type") == "message":
                 self._populate(val.get("entries", []), field_item)
+
+    def _tree_expand_all(self) -> None:
+        self._tree.expandAll()
+
+    def _tree_collapse_all(self) -> None:
+        self._tree.collapseAll()
+
+    def _apply_filter(self, text: str) -> None:
+        """Show/hide rows whose field name or value contains the search text."""
+        self._filter_items(self._model.invisibleRootItem(), text.lower())
+
+    def _filter_items(self, parent: QStandardItem, text: str) -> bool:
+        any_visible = False
+        for row in range(parent.rowCount()):
+            key_item = parent.child(row, 0)
+            val_item = parent.child(row, 1)
+            if key_item is None:
+                continue
+            child_visible = self._filter_items(key_item, text)
+            # Match against the full (untruncated) value where available, so a search
+            # can find text even in a value the tree cell itself shows truncated.
+            full_text = val_item.data(_FULLTEXT_ROLE) if val_item else None
+            val_text = full_text if full_text is not None else (val_item.text() if val_item else "")
+            key_match = not text or text in key_item.text().lower()
+            val_match = text in val_text.lower()
+            visible = key_match or val_match or child_visible
+            self._tree.setRowHidden(
+                row,
+                self._model.indexFromItem(parent),
+                not visible,
+            )
+            any_visible = any_visible or visible
+        return any_visible
 
     def _current_row_items(self) -> tuple[QStandardItem, QStandardItem] | None:
         index = self._tree.currentIndex()


### PR DESCRIPTION
Matches the other tree-based viewers; search matches each field's full value even when the tree cell shows it truncated. Closes #63.