### PR TITLE
fix: prevent protobuf viewer Qt int overflow on uint64 fields

### DIFF
--- a/crush/tests/test_protobuf_viewer.py
+++ b/crush/tests/test_protobuf_viewer.py
@@ -181,6 +181,18 @@ def test_export_subtree_enabled_only_on_field_rows_not_interpretation_rows(qapp)
         assert interp_key_item.data(_ENTRY_ROLE) is None  # hint row -> not exportable
 
 
+def test_tree_stores_uint64_max_entry_without_qt_int_overflow(qapp) -> None:
+    """Subtree export metadata must not make Qt convert uint64 values to signed ints."""
+    raw = b"\x08" + _varint((1 << 64) - 1)
+    decoded, warning, _ = _decode_message(raw)
+    assert not warning
+
+    widget = ProtobufTreeWidget(decoded)
+    root = widget._model.invisibleRootItem()
+    field_item = root.child(0, 0)
+    assert field_item.data(_ENTRY_ROLE) is not None
+
+
 def test_export_entries_writes_text_file(qapp, tmp_path, monkeypatch) -> None:
     from PySide6.QtWidgets import QFileDialog
 

--- a/crush/tests/test_tree_viewer.py
+++ b/crush/tests/test_tree_viewer.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 - now Marco Neumann (kalink0)
+"""Tests for TreeViewer (crush/viewers/tree_viewer.py)."""
+from __future__ import annotations
+
+from crush.viewers.tree_viewer import TreeViewer
+
+_UINT64_MAX = (1 << 64) - 1
+
+
+def _select_only_row(widget: TreeViewer) -> None:
+    index = widget._model.index(0, 0)
+    widget._tree.setCurrentIndex(index)
+
+
+def test_scalar_uint64_max_does_not_crash_and_roundtrips(qapp) -> None:
+    """A bare int in the uint64 range (e.g. an NSKeyedArchiver UID) must not
+    make Qt's QVariant conversion raise OverflowError while building the
+    tree, and must still be retrievable afterwards."""
+    widget = TreeViewer({"uid": _UINT64_MAX})
+    _select_only_row(widget)
+    obj, key = widget._current_obj_and_key()
+    assert key == "uid"
+    assert obj == _UINT64_MAX
+
+
+def test_dict_containing_uint64_max_does_not_crash_and_roundtrips(qapp) -> None:
+    widget = TreeViewer({"outer": {"value": _UINT64_MAX}})
+    _select_only_row(widget)
+    obj, key = widget._current_obj_and_key()
+    assert key == "outer"
+    assert obj == {"value": _UINT64_MAX}
+
+
+def test_list_containing_uint64_max_does_not_crash_and_roundtrips(qapp) -> None:
+    widget = TreeViewer({"items": [_UINT64_MAX]})
+    _select_only_row(widget)
+    obj, key = widget._current_obj_and_key()
+    assert key == "items"
+    assert obj == [_UINT64_MAX]

--- a/crush/viewers/protobuf_viewer.py
+++ b/crush/viewers/protobuf_viewer.py
@@ -186,6 +186,13 @@ _FULLTEXT_ROLE = Qt.ItemDataRole.UserRole + 1
 _ENTRY_ROLE = Qt.ItemDataRole.UserRole + 2  # the field's original decoded entry dict
 
 
+class _EntryRef:
+    """Keep decoded entries opaque to Qt's QVariant conversion."""
+
+    def __init__(self, entry: dict[str, Any]) -> None:
+        self.entry = entry
+
+
 def _entry_to_jsonable(entry: dict[str, Any]) -> dict[str, Any]:
     """Convert one decoded protobuf entry to a JSON-safe dict.
 
@@ -329,7 +336,7 @@ class ProtobufTreeWidget(QWidget):
             wt_item = QStandardItem(wire_type)
             val_item.setData(raw_bytes, _RAW_ROLE)
             val_item.setData(full_text, _FULLTEXT_ROLE)
-            field_item.setData(entry, _ENTRY_ROLE)
+            field_item.setData(_EntryRef(entry), _ENTRY_ROLE)
             for item in (field_item, val_item, wt_item):
                 item.setEditable(False)
             parent.appendRow([field_item, val_item, wt_item])
@@ -453,7 +460,8 @@ class ProtobufTreeWidget(QWidget):
         value = val_item.data(_FULLTEXT_ROLE)
         value = value if value is not None else val_item.text()
         raw_bytes = val_item.data(_RAW_ROLE)
-        subtree_entry = key_item.data(_ENTRY_ROLE)  # None for interpretation hint rows
+        subtree_ref = key_item.data(_ENTRY_ROLE)  # None for interpretation hint rows
+        subtree_entry = subtree_ref.entry if isinstance(subtree_ref, _EntryRef) else None
 
         menu = QMenu(self)
         inspect_action = menu.addAction("Inspect BLOB…")

--- a/crush/viewers/tree_viewer.py
+++ b/crush/viewers/tree_viewer.py
@@ -25,6 +25,16 @@ from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 _USER_ROLE = Qt.ItemDataRole.UserRole
 
 
+class _ObjRef:
+    """Keep the node's original decoded value opaque to Qt's QVariant
+    conversion — a bare dict/list/int stored via setData() gets walked by
+    shiboken looking for a native Qt type, and a value in the uint64 range
+    (e.g. an NSKeyedArchiver UID) raises OverflowError partway through."""
+
+    def __init__(self, obj: Any) -> None:
+        self.obj = obj
+
+
 class TreeViewer(QWidget):
     """Viewer for plist / XML / any nested dict/list structure."""
 
@@ -123,7 +133,7 @@ class TreeViewer(QWidget):
             key_item = QStandardItem(str(key))
             val_item = QStandardItem(f"({len(display_obj)} keys)")
             type_item = QStandardItem(classname if classname else "dict")
-            key_item.setData(obj, _USER_ROLE)
+            key_item.setData(_ObjRef(obj), _USER_ROLE)
             key_item.setEditable(False)
             val_item.setEditable(False)
             type_item.setEditable(False)
@@ -135,7 +145,7 @@ class TreeViewer(QWidget):
             key_item = QStandardItem(str(key))
             val_item = QStandardItem(f"({len(obj)} items)")
             type_item = QStandardItem(type_name)
-            key_item.setData(obj, _USER_ROLE)
+            key_item.setData(_ObjRef(obj), _USER_ROLE)
             key_item.setEditable(False)
             val_item.setEditable(False)
             type_item.setEditable(False)
@@ -147,7 +157,7 @@ class TreeViewer(QWidget):
             key_item = QStandardItem(str(key))
             val_item = QStandardItem(f"<BLOB {len(obj):,} B>")
             type_item = QStandardItem("bytes")
-            key_item.setData(obj, _USER_ROLE)
+            key_item.setData(_ObjRef(obj), _USER_ROLE)
             key_item.setEditable(False)
             val_item.setEditable(False)
             type_item.setEditable(False)
@@ -157,7 +167,7 @@ class TreeViewer(QWidget):
             key_item = QStandardItem(str(key))
             val_item = QStandardItem(str(obj))
             type_item = QStandardItem(type_name)
-            key_item.setData(obj, _USER_ROLE)
+            key_item.setData(_ObjRef(obj), _USER_ROLE)
             key_item.setEditable(False)
             val_item.setEditable(False)
             type_item.setEditable(False)
@@ -240,7 +250,9 @@ class TreeViewer(QWidget):
         key_item = self._model.itemFromIndex(self._model.index(row, 0, parent_index))
         if key_item is None:
             return None, ""
-        return key_item.data(_USER_ROLE), key_item.text()
+        ref = key_item.data(_USER_ROLE)
+        obj = ref.obj if isinstance(ref, _ObjRef) else None
+        return obj, key_item.text()
 
     def _on_context_menu(self, pos: object) -> None:
         index = self._tree.indexAt(pos)


### PR DESCRIPTION
Fixes a protobuf viewer crash when decoded entries contain large unsigned integers. The tree now stores subtree export metadata behind an opaque Python wrapper so PySide does not try to marshal nested dict values through Qt’s signed integer conversion path.
Adds a regression test covering uint64 max values during tree population.

Output was like this when opening certain protobuf files:
```
OverflowError
OverflowError
OverflowError
OverflowError
OverflowError
OverflowError
C:\path\to\crush-forensics\crush-forensics\crush\viewers\protobuf_viewer.py:332: RuntimeWarning: libshiboken: Overflow: Value 258 exceeds limits of type  [signed] "int" (4bytes).
  field_item.setData(entry, _ENTRY_ROLE)
```