### PR TITLE
feat: add submenu to open blob in tab for sqlite view

### DIFF
--- a/crush/core/vfs.py
+++ b/crush/core/vfs.py
@@ -1119,11 +1119,14 @@ class SevenZipVFS(VFS):
 class BytesVFS(VFS):
     """VFS backed by a single in-memory bytes object (for artifact chaining)."""
 
-    def __init__(self, data: bytes, name: str = "blob") -> None:
+    def __init__(self, data: bytes, name: str = "blob", path: str | None = None) -> None:
         self._data = data
+        if path is None and name.startswith("/"):
+            path = name
+            name = name.rstrip("/").rsplit("/", 1)[-1] or "blob"
         self._root = VFSNode(
             name=name,
-            path=f"/{name}",
+            path=path or f"/{name}",
             is_dir=False,
             size=len(data),
         )

--- a/crush/ui/main_window.py
+++ b/crush/ui/main_window.py
@@ -1382,10 +1382,14 @@ class MainWindow(QMainWindow):
         from crush.core.vfs import BytesVFS
 
         if parser_display_name == "__hex__":
-            from crush.viewers.hex_viewer import HexViewer
-            viewer = HexViewer(data, self)
-            self._viewer_tabs.addTab(viewer, "hex")
-            self._viewer_tabs.setCurrentIndex(self._viewer_tabs.count() - 1)
+            from crush.parsers.base import ParseResult
+
+            vfs = BytesVFS(data, name=filename_hint)
+            node = vfs.root()
+            result = ParseResult(viewer_type="hex", data=data)
+            self._show_result(node, result, vfs)
+            self._props_panel.update_properties(node, result.metadata, vfs)
+            self._status.showMessage(f"Opened artifact: {filename_hint}  [Hex]")
             return
         if parser_display_name == "__text__":
             from crush.parsers.base import ParseResult

--- a/crush/ui/main_window.py
+++ b/crush/ui/main_window.py
@@ -1387,6 +1387,21 @@ class MainWindow(QMainWindow):
             self._viewer_tabs.addTab(viewer, "hex")
             self._viewer_tabs.setCurrentIndex(self._viewer_tabs.count() - 1)
             return
+        if parser_display_name == "__text__":
+            from crush.parsers.base import ParseResult
+            from crush.core.vfs import BytesVFS
+
+            vfs = BytesVFS(data, name=filename_hint)
+            node = vfs.root()
+            try:
+                text = data.decode("utf-8")
+            except Exception:
+                text = data.decode("utf-8", errors="replace")
+            result = ParseResult(viewer_type="text", data=text)
+            self._show_result(node, result, vfs)
+            self._props_panel.update_properties(node, result.metadata, vfs)
+            self._status.showMessage(f"Opened artifact: {filename_hint}  [Text]")
+            return
 
         vfs = BytesVFS(data, name=filename_hint)
         node = vfs.root()
@@ -1748,6 +1763,8 @@ class MainWindow(QMainWindow):
         base_view = make_viewer(result, node, vfs, self)
         if hasattr(base_view, "open_bytes_requested"):
             base_view.open_bytes_requested.connect(self._open_bytes_as_artifact)
+        if hasattr(base_view, "open_bytes_with_format_requested"):
+            base_view.open_bytes_with_format_requested.connect(self._open_bytes_with_format)
         if hasattr(base_view, "open_table_requested"):
             base_view.open_table_requested.connect(self._open_table_as_tab)
         possibly_encrypted = result.metadata.get("Possibly Encrypted")

--- a/crush/viewers/__init__.py
+++ b/crush/viewers/__init__.py
@@ -18,7 +18,10 @@ def _register_builtin_viewers() -> None:
     from crush.viewers.realm_viewer import RealmViewer
     from crush.viewers.leveldb_viewer import LevelDbViewer
 
-    ViewerRegistry.register("table", lambda r, n, v, p: TableViewer(r.data, p, **r.viewer_hints))
+    ViewerRegistry.register(
+        "table",
+        lambda r, n, v, p: TableViewer(r.data, p, source_name=n.name, **r.viewer_hints),
+    )
     ViewerRegistry.register("tree", lambda r, n, v, p: TreeViewer(r.data, p))
     ViewerRegistry.register(
         "tree_text", lambda r, n, v, p: TreeTextViewer(r.data, p, **r.viewer_hints)

--- a/crush/viewers/table_viewer.py
+++ b/crush/viewers/table_viewer.py
@@ -479,6 +479,8 @@ class TableViewer(QWidget):
         }
     """
     open_bytes_requested = Signal(bytes, str)
+    open_bytes_with_format_requested = Signal(bytes, str, object)
+
     def __init__(
         self,
         data: dict[str, Any],
@@ -2305,18 +2307,21 @@ class TableViewer(QWidget):
         blob_preview = menu.addAction("Inspect Cell…")
         blob_hex = menu.addAction("Open in Hex")
         blob_export = menu.addAction("Export…")
-        open_tab = menu.addAction("Open as new tab")
+        open_tab_menu = menu.addMenu("Open as new tab")
+        open_tab_auto = open_tab_menu.addAction("Auto-detect")
+        open_tab_hex = open_tab_menu.addAction("Hex")
+        open_tab_text = open_tab_menu.addAction("Text")
+        open_tab_proto = open_tab_menu.addAction("Protobuf")
         blob_bytes = _coerce_blob(blob)
         display_val = self._table_view.model().data(index, Qt.ItemDataRole.DisplayRole)
         display_str = str(display_val) if display_val is not None else ""
         has_display = bool(display_str)
         is_blob_placeholder = display_str.startswith("<BLOB ") and display_str.endswith(" B>")
         if blob_bytes is None and not has_display:
-            open_tab.setEnabled(False)
+            open_tab_menu.setEnabled(False)
             blob_preview.setEnabled(False)
             blob_hex.setEnabled(False)
             blob_export.setEnabled(False)
-            open_tab.setEnabled(False)
         if blob_bytes is None and has_display:
             blob_preview.setEnabled(True)
             blob_hex.setEnabled(True)
@@ -2350,7 +2355,7 @@ class TableViewer(QWidget):
                 self._export_blob(blob_bytes)
             elif has_display:
                 self._export_blob(str(display_val).encode("utf-8", errors="replace"))
-        elif action == open_tab:
+        elif action in {open_tab_auto, open_tab_hex, open_tab_text, open_tab_proto}:
             data_to_open = blob_bytes
             if data_to_open is None and has_display:
                 data_to_open = str(display_val).encode("utf-8", errors="replace")
@@ -2358,7 +2363,20 @@ class TableViewer(QWidget):
                 col_header = self._table_view.model().headerData(
                     index.column(), Qt.Orientation.Horizontal
                 ) or "blob"
-                self.open_bytes_requested.emit(data_to_open, str(col_header))
+                if action == open_tab_auto:
+                    self.open_bytes_requested.emit(data_to_open, str(col_header))
+                elif action == open_tab_hex:
+                    self.open_bytes_with_format_requested.emit(
+                        data_to_open, str(col_header), "__hex__"
+                    )
+                elif action == open_tab_text:
+                    self.open_bytes_with_format_requested.emit(
+                        data_to_open, str(col_header), "__text__"
+                    )
+                elif action == open_tab_proto:
+                    self.open_bytes_with_format_requested.emit(
+                        data_to_open, str(col_header), "Protobuf (schema-less)"
+                    )
 
     def _on_header_context_menu(self, pos: object) -> None:
         header = self._table_view.horizontalHeader()

--- a/crush/viewers/table_viewer.py
+++ b/crush/viewers/table_viewer.py
@@ -84,6 +84,14 @@ from crush.viewers.blob_inspector import BlobInspector
 _MAX_COL_WIDTH = 400
 _QUERY_ROW_LIMIT = 10_000
 _COLUMN_SIZE_SAMPLE = 250
+_VIRTUAL_PATH_BAD_CHARS = re.compile(r"[\\/:\x00-\x1f]+")
+
+
+def _virtual_path_component(value: object, fallback: str) -> str:
+    text = str(value or "").strip()
+    text = _VIRTUAL_PATH_BAD_CHARS.sub("_", text)
+    text = text.strip(" .")
+    return text or fallback
 
 
 class _QueryResultModel(QAbstractTableModel):
@@ -487,9 +495,11 @@ class TableViewer(QWidget):
         parent: QWidget | None = None,
         show_db_tabs: bool = True,
         summary_nav_table: str | None = None,
+        source_name: str = "sqlite",
     ) -> None:
         super().__init__(parent)
         self._data = data
+        self._source_name = source_name
         self._show_db_tabs = show_db_tabs
         self._summary_nav_table = summary_nav_table
         self._col_ts_formats: dict[int, str] = {}
@@ -2363,20 +2373,31 @@ class TableViewer(QWidget):
                 col_header = self._table_view.model().headerData(
                     index.column(), Qt.Orientation.Horizontal
                 ) or "blob"
+                artifact_path = self._virtual_cell_path(index, col_header)
                 if action == open_tab_auto:
-                    self.open_bytes_requested.emit(data_to_open, str(col_header))
+                    self.open_bytes_requested.emit(data_to_open, artifact_path)
                 elif action == open_tab_hex:
                     self.open_bytes_with_format_requested.emit(
-                        data_to_open, str(col_header), "__hex__"
+                        data_to_open, artifact_path, "__hex__"
                     )
                 elif action == open_tab_text:
                     self.open_bytes_with_format_requested.emit(
-                        data_to_open, str(col_header), "__text__"
+                        data_to_open, artifact_path, "__text__"
                     )
                 elif action == open_tab_proto:
                     self.open_bytes_with_format_requested.emit(
-                        data_to_open, str(col_header), "Protobuf (schema-less)"
+                        data_to_open, artifact_path, "Protobuf (schema-less)"
                     )
+
+    def _virtual_cell_path(self, index: QModelIndex, col_header: object) -> str:
+        db_name = _virtual_path_component(self._source_name, "sqlite")
+        table_name = "query" if self._query_results_active else self._table_combo.currentText()
+        table = _virtual_path_component(table_name, "table")
+        column = _virtual_path_component(col_header, "column")
+        row_index = self._table_view.model().index(index.row(), 0)
+        row_value = self._table_view.model().data(row_index, Qt.ItemDataRole.DisplayRole)
+        row = _virtual_path_component(row_value, str(index.row() + 1))
+        return f"/virtual/{db_name}/{table}/{column}/{row}"
 
     def _on_header_context_menu(self, pos: object) -> None:
         header = self._table_view.horizontalHeader()


### PR DESCRIPTION
this is stacked on #72 so i am hoping this is coming through alright. it requires the multiple options of the submenu in that pr. i wanted it to be a separate pr for review purposes, but i branched it from the branch in 72.

previously, opening virtual files from a sqlite cell would make a file in the VFS as the name of the column it came from. if you try to open blob data into a tab from a different row in the same column, it would replace the already open tab with the newly chosen data. it would not allow you to have multiple tabs open from the same column.

this pr is creating the virtual file with a path to be unique. based on: `/virtual/sqlitefilename.db/tablename/columnname/rownumber`