### PR TITLE
feat: WAL Frames content column; fix WAL-blind SQLite recovery scanne…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Crush will be documented in this file.
 
 ## Unreleased
 
+### New Features
+
+- SQLite Table Viewer's WAL Frames tab now has a Content column, decoding each frame's page into its actual row values (with real column names when the page maps to a known table) instead of only frame/page/status metadata.
+
+### Bug Fixes
+
+- Fixed the SQLite Freelist Recovery, Freeblocks, and Unallocated Space scanners (and page→table attribution) reading only the database's frozen base file, ignoring a live, not-yet-checkpointed `-wal` sidecar — a delete/drop recorded only in the WAL could look like nothing was ever freed.
+- Fixed the Freelist Recovery tab only appearing when a live PRAGMA reported freed pages, unlike Freeblocks/Unallocated Space (always shown regardless); it's now always shown too, with a status message distinguishing "nothing recoverable" from "no freed pages at all".
+- Fixed Freeblocks' Data column rendering an all-zero freeblock as an apparently empty cell (NUL bytes render invisibly) instead of stating so explicitly.
+- Fixed the SQLite Table Viewer's status line below the SQL box keeping a previous tab's message (e.g. WAL Frames' hex-viewer hint) after switching to a plain table, which never sets its own. Same bug class as [#73](https://github.com/kalink0/crush-forensics/issues/73).
+- Fixed the MMKV parser trusting a store's `.crc` meta file's "non-zero vector" field as proof of AES encryption — confirmed false-positive on a real react-native-mmkv store with demonstrably plaintext data. It now only reports "encrypted" when the store genuinely fails to read as plaintext.
+
 ## v0.18.0 - 2026-09-05
 
 **Focus: MMKV support; full Realm format-9 (pre-Cluster) row-level parsing; SQLite blob-cell tab menu with per-cell provenance; `--focus` CLI flag; bundled peach updated to v0.6.0.**

--- a/crush/core/sqlite_freeblocks.py
+++ b/crush/core/sqlite_freeblocks.py
@@ -63,7 +63,9 @@ def extract_freeblocks(page: bytes) -> list[dict[str, Any]]:
     return freeblocks
 
 
-def scan_database_freeblocks(db_path: Path, page_size: int) -> list[dict[str, Any]]:
+def scan_database_freeblocks(
+    db_path: Path, page_size: int, wal_pages: dict[int, bytes] | None = None
+) -> list[dict[str, Any]]:
     """Scan every page in *db_path* for freeblocks.
 
     Returns one entry per freeblock: ``{"page": int, "offset": int, "size":
@@ -72,18 +74,29 @@ def scan_database_freeblocks(db_path: Path, page_size: int) -> list[dict[str, An
     a freelist leaf page can still carry both intact cells (see
     ``sqlite_freelist.py``) and, separately, its own freeblock leftovers
     from before it was freed.
+
+    *wal_pages* (see sqlite_wal.build_wal_page_overlay()) is checked before
+    the base file for each page number — on a live WAL-mode database, a
+    page's most recent freeblock layout can sit only in a not-yet-
+    checkpointed -wal frame, and scanning the base file alone would show a
+    stale (or entirely wrong) freeblock list for that page.
     """
     try:
         page_count = db_path.stat().st_size // page_size if page_size else 0
     except OSError:
         return []
+    if wal_pages:
+        page_count = max(page_count, max(wal_pages, default=0))
 
     results: list[dict[str, Any]] = []
     try:
         with open(db_path, "rb") as fh:
             for page_num in range(1, page_count + 1):
-                fh.seek((page_num - 1) * page_size)
-                page = fh.read(page_size)
+                if wal_pages and page_num in wal_pages:
+                    page = wal_pages[page_num]
+                else:
+                    fh.seek((page_num - 1) * page_size)
+                    page = fh.read(page_size)
                 if len(page) != page_size:
                     continue
                 for fb in extract_freeblocks(page):

--- a/crush/core/sqlite_freelist.py
+++ b/crush/core/sqlite_freelist.py
@@ -30,8 +30,19 @@ _HEADER_FIRST_TRUNK_OFFSET = 32
 _HEADER_FREELIST_COUNT_OFFSET = 36
 
 
-def read_raw_page(db_path: Path, page_num: int, page_size: int) -> bytes | None:
-    """Return raw bytes for 1-indexed *page_num*, or None if unreadable."""
+def read_raw_page(
+    db_path: Path, page_num: int, page_size: int, wal_pages: dict[int, bytes] | None = None
+) -> bytes | None:
+    """Return raw bytes for 1-indexed *page_num*, or None if unreadable.
+
+    *wal_pages* (see sqlite_wal.build_wal_page_overlay()) is checked first —
+    a page still on the freelist per the base file's header can, on a live
+    WAL-mode database, already have a newer committed version sitting only
+    in the not-yet-checkpointed -wal file; without this, callers would read
+    stale base-file bytes for a page number the header itself says to trust.
+    """
+    if wal_pages and page_num in wal_pages:
+        return wal_pages[page_num]
     if page_num < 1 or page_size <= 0:
         return None
     offset = (page_num - 1) * page_size
@@ -44,10 +55,14 @@ def read_raw_page(db_path: Path, page_num: int, page_size: int) -> bytes | None:
     return data if len(data) == page_size else None
 
 
-def _read_page_via_handle(fh: Any, page_num: int, page_size: int) -> bytes | None:
+def _read_page_via_handle(
+    fh: Any, page_num: int, page_size: int, wal_pages: dict[int, bytes] | None = None
+) -> bytes | None:
     """Like read_raw_page(), but reuses an already-open file handle instead
     of opening the file fresh — avoids one open()/close() per page when
     walking many pages in a loop."""
+    if wal_pages and page_num in wal_pages:
+        return wal_pages[page_num]
     if page_num < 1 or page_size <= 0:
         return None
     try:
@@ -58,12 +73,21 @@ def _read_page_via_handle(fh: Any, page_num: int, page_size: int) -> bytes | Non
     return data if len(data) == page_size else None
 
 
-def walk_freelist_pages(db_path: Path, page_size: int) -> list[dict[str, Any]]:
+def walk_freelist_pages(
+    db_path: Path, page_size: int, wal_pages: dict[int, bytes] | None = None
+) -> list[dict[str, Any]]:
     """Walk the freelist trunk chain, returning one entry per freed page.
 
     Each entry is ``{"page": int, "kind": "trunk" | "leaf"}``.  The walk is
     bounded by the freelist page count declared in the database header, so a
     corrupt or cyclic chain is stopped defensively rather than looping.
+
+    *wal_pages* (see sqlite_wal.build_wal_page_overlay()) lets the header and
+    every trunk/leaf page be read through a live -wal file's not-yet-
+    checkpointed content where present, instead of only the base file's
+    frozen bytes — a header whose freelist fields were last updated by a
+    still-in-WAL transaction would otherwise look empty even though the
+    connection-level PRAGMA freelist_count already reports pages.
     """
     try:
         fh = open(db_path, "rb")
@@ -71,7 +95,7 @@ def walk_freelist_pages(db_path: Path, page_size: int) -> list[dict[str, Any]]:
         return []
 
     try:
-        header = _read_page_via_handle(fh, 1, page_size)
+        header = _read_page_via_handle(fh, 1, page_size, wal_pages)
         if header is None or len(header) < _HEADER_FREELIST_COUNT_OFFSET + 4:
             return []
 
@@ -88,7 +112,7 @@ def walk_freelist_pages(db_path: Path, page_size: int) -> list[dict[str, Any]]:
         while trunk_num and trunk_num not in visited and budget > 0:
             visited.add(trunk_num)
             budget -= 1
-            trunk = _read_page_via_handle(fh, trunk_num, page_size)
+            trunk = _read_page_via_handle(fh, trunk_num, page_size, wal_pages)
             if trunk is None or len(trunk) < 8:
                 break
             entries.append({"page": trunk_num, "kind": "trunk"})
@@ -122,6 +146,7 @@ def carve_freelist_rows(
     db_path: Path,
     page_size: int,
     entries: list[dict[str, Any]] | None = None,
+    wal_pages: dict[int, bytes] | None = None,
 ) -> list[dict[str, Any]]:
     """Carve leftover table-leaf rows out of freed pages.
 
@@ -146,7 +171,7 @@ def carve_freelist_rows(
     reconstruct what can be verified).
     """
     if entries is None:
-        entries = walk_freelist_pages(db_path, page_size)
+        entries = walk_freelist_pages(db_path, page_size, wal_pages)
 
     freelist_page_set = {e["page"] for e in entries if e["kind"] == "leaf"}
 
@@ -158,12 +183,12 @@ def carve_freelist_rows(
     def _overflow_reader(page_num: int) -> bytes | None:
         if page_num not in freelist_page_set:
             return None
-        return _read_page_via_handle(fh, page_num, page_size)
+        return _read_page_via_handle(fh, page_num, page_size, wal_pages)
 
     try:
         carved: list[dict[str, Any]] = []
         for entry in entries:
-            page = _read_page_via_handle(fh, entry["page"], page_size)
+            page = _read_page_via_handle(fh, entry["page"], page_size, wal_pages)
             if page is None:
                 continue
             rows = parse_table_leaf_page(

--- a/crush/core/sqlite_unallocated.py
+++ b/crush/core/sqlite_unallocated.py
@@ -49,24 +49,36 @@ def extract_unallocated_space(page: bytes) -> dict[str, Any] | None:
     return {"offset": pointer_array_end, "size": len(data), "data": data}
 
 
-def scan_database_unallocated(db_path: Path, page_size: int) -> list[dict[str, Any]]:
+def scan_database_unallocated(
+    db_path: Path, page_size: int, wal_pages: dict[int, bytes] | None = None
+) -> list[dict[str, Any]]:
     """Scan every table-leaf page in *db_path* for non-empty unallocated gaps.
 
     Returns one entry per page with a non-zero gap: ``{"page", "offset",
     "size", "data"}``. Applies to live-allocated and freelist leaf pages
     alike, same as `sqlite_freeblocks.scan_database_freeblocks`.
+
+    *wal_pages* (see sqlite_wal.build_wal_page_overlay()) is checked before
+    the base file for each page number, same reasoning as in
+    scan_database_freeblocks: a page's current gap can exist only in a
+    not-yet-checkpointed -wal frame on a live WAL-mode database.
     """
     try:
         page_count = db_path.stat().st_size // page_size if page_size else 0
     except OSError:
         return []
+    if wal_pages:
+        page_count = max(page_count, max(wal_pages, default=0))
 
     results: list[dict[str, Any]] = []
     try:
         with open(db_path, "rb") as fh:
             for page_num in range(1, page_count + 1):
-                fh.seek((page_num - 1) * page_size)
-                page = fh.read(page_size)
+                if wal_pages and page_num in wal_pages:
+                    page = wal_pages[page_num]
+                else:
+                    fh.seek((page_num - 1) * page_size)
+                    page = fh.read(page_size)
                 if len(page) != page_size:
                     continue
                 entry = extract_unallocated_space(page)

--- a/crush/core/sqlite_wal.py
+++ b/crush/core/sqlite_wal.py
@@ -277,6 +277,48 @@ def get_page_type(page: bytes) -> int | None:
 # Page → table attribution
 # ---------------------------------------------------------------------------
 
+# Same magic pair the WAL frame classifier in table_viewer.py's _get_wal_frames
+# checks (_WAL_MAGIC there) -- kept local here since this module has no
+# dependency on the viewer.
+_WAL_MAGIC = (0x377F0682, 0x377F0683)
+
+
+def build_wal_page_overlay(wal_data: bytes | None, page_size: int) -> dict[int, bytes]:
+    """Return {page_num: latest committed page bytes} from a WAL file's
+    salt-valid frames.
+
+    A page's *logical* current content is its base-file copy unless a later,
+    not-yet-checkpointed WAL frame overrides it -- which is exactly what a
+    live SQLite connection already returns transparently for any query, WAL
+    or no WAL. Any code that instead reads a database file's raw bytes
+    directly (as every recovery scanner in sqlite_freelist.py,
+    sqlite_freeblocks.py and sqlite_unallocated.py does, since none of them
+    go through sqlite3) sees only the frozen base-file state and silently
+    misses -- or reports as still-live -- whatever the WAL has since
+    changed. Passing this overlay's bytes for a page number, falling back to
+    the base file otherwise, closes that gap without needing sqlite3 at all.
+    """
+    wal_pages: dict[int, bytes] = {}
+    if not wal_data or not page_size or len(wal_data) < 32:
+        return wal_pages
+    magic = struct.unpack_from(">I", wal_data, 0)[0]
+    if magic not in _WAL_MAGIC:
+        return wal_pages
+    salt1 = struct.unpack_from(">I", wal_data, 16)[0]
+    salt2 = struct.unpack_from(">I", wal_data, 20)[0]
+    frame_size = 24 + page_size
+    offset = 32
+    # Collect last valid frame per page (active)
+    while offset + frame_size <= len(wal_data):
+        pn  = struct.unpack_from(">I", wal_data, offset)[0]
+        fs1 = struct.unpack_from(">I", wal_data, offset + 8)[0]
+        fs2 = struct.unpack_from(">I", wal_data, offset + 12)[0]
+        if fs1 == salt1 and fs2 == salt2:
+            wal_pages[pn] = wal_data[offset + 24: offset + 24 + page_size]
+        offset += frame_size
+    return wal_pages
+
+
 def build_page_table_map(
     conn: sqlite3.Connection,
     wal_data: bytes | None = None,
@@ -290,25 +332,7 @@ def build_page_table_map(
     numbers.  Index pages and non-table objects are excluded.
     """
     mapping: dict[int, str] = {}
-
-    # Build WAL frame lookup: page_num → latest page bytes (active frames only)
-    wal_pages: dict[int, bytes] = {}
-    if wal_data and page_size:
-        if len(wal_data) >= 32:
-            magic = struct.unpack_from(">I", wal_data, 0)[0]
-            if magic in (0x377F0682, 0x377F0683):
-                salt1 = struct.unpack_from(">I", wal_data, 16)[0]
-                salt2 = struct.unpack_from(">I", wal_data, 20)[0]
-                frame_size = 24 + page_size
-                offset = 32
-                # Collect last valid frame per page (active)
-                while offset + frame_size <= len(wal_data):
-                    pn    = struct.unpack_from(">I", wal_data, offset)[0]
-                    fs1   = struct.unpack_from(">I", wal_data, offset + 8)[0]
-                    fs2   = struct.unpack_from(">I", wal_data, offset + 12)[0]
-                    if fs1 == salt1 and fs2 == salt2:
-                        wal_pages[pn] = wal_data[offset + 24: offset + 24 + page_size]
-                    offset += frame_size
+    wal_pages = build_wal_page_overlay(wal_data, page_size)
 
     # Read sqlite_master for table root pages and schemas
     try:

--- a/crush/parsers/mmkv_parser.py
+++ b/crush/parsers/mmkv_parser.py
@@ -17,13 +17,18 @@ from __future__ import annotations
 import os
 import struct
 import tempfile
-from typing import Any
+from typing import Any, cast
 
 from crush.core.passwords import WrongPasswordError
 from crush.core.vfs import VFS, VFSNode, find_sibling
 from crush.parsers.base import AbstractParser, ParseResult
 from crush.third_party.mmkv_parser import MMKVError, decode_value, read_entries
-from crush.third_party.mmkv_parser.mmkv_parser import _read_varint
+from crush.third_party.mmkv_parser.mmkv_parser import (
+    _HEADER_LENGTH,
+    _read_varint,
+    _region_size,
+    _walk,
+)
 
 # MMKVMetaInfo (.crc file) layout, independently verified against Tencent/MMKV's
 # MMKVMetaInfo.hpp: crc u32, version u32, sequence u32, aesVector[16], actualSize u32.
@@ -55,6 +60,32 @@ def _read_meta_info(crc_bytes: bytes | None) -> dict[str, Any] | None:
         "encrypted": any(vector),
         "actual_size": actual_size if version >= _META_VERSION_ACTUAL_SIZE else None,
     }
+
+
+def _try_plain_walk(raw: bytes) -> list[tuple[str, bytes]] | None:
+    """Attempt to read *raw* as an unencrypted MMKV store, ignoring the .crc
+    meta file's encryption flag entirely.
+
+    The .crc file's "non-zero vector means AES-encrypted" heuristic is only
+    as good as the MMKVMetaInfo layout it's read against — seen false-
+    positive in the field on a real react-native-mmkv store whose meta
+    "version" field was far higher than anything this layout has been
+    verified against (61, vs. the 1-4 range the known struct evolution
+    covers), producing a non-zero vector for a demonstrably plaintext store.
+    Rather than trust the flag blindly, confirm it: a genuinely encrypted
+    store fed through here as if it weren't will, per read_entries()'s own
+    documented invariant, either yield nothing or leave a tail unread.
+    """
+    if len(raw) < _HEADER_LENGTH:
+        return None
+    region_size = _region_size(raw, None)  # type: ignore[no-untyped-call]
+    if region_size == 0 or _HEADER_LENGTH + region_size > len(raw):
+        return None
+    region = raw[_HEADER_LENGTH:_HEADER_LENGTH + region_size]
+    entries, unread = _walk(region)  # type: ignore[no-untyped-call]
+    if not entries or unread:
+        return None
+    return cast(list[tuple[str, bytes]], entries)
 
 
 _TYPE_LABELS: dict[type, str] = {str: "string", int: "int", bytes: "bytes"}
@@ -153,56 +184,66 @@ class MMKVParser(AbstractParser):
                 crc_bytes = None
 
         meta_info = _read_meta_info(crc_bytes)
+        meta_flagged_encrypted = meta_info is not None and meta_info["encrypted"]
+        false_positive_encrypted_flag = False
 
-        if meta_info is not None and meta_info["encrypted"] and password is None:
-            return ParseResult(
-                viewer_type="tree",
-                data={
-                    "error": "This MMKV store is AES-encrypted.",
-                    "hint": 'Use "Open as -> MMKV (Encrypted)..." and supply the key.',
-                },
-                metadata={
-                    "Format": "MMKV Key-Value Store (encrypted)",
-                    "File size": f"{node.size:,} B",
-                    "Encrypted": "yes",
-                },
-            )
-
-        tmp_dir = tempfile.mkdtemp(prefix="crush_mmkv_")
-        tmp_path = os.path.join(tmp_dir, node.name)
-        try:
-            with open(tmp_path, "wb") as f:
-                f.write(raw)
-            if crc_bytes is not None:
-                with open(tmp_path + ".crc", "wb") as f:
-                    f.write(crc_bytes)
-            try:
-                entries = read_entries(  # type: ignore[no-untyped-call]
-                    tmp_path, key=password, aes256=aes256
-                )
-            except MMKVError as exc:
-                msg = str(exc)
-                if password is not None and "did not decrypt" in msg:
-                    raise WrongPasswordError(msg) from exc
+        if meta_flagged_encrypted and password is None:
+            plain_entries = _try_plain_walk(raw)
+            if plain_entries is None:
                 return ParseResult(
                     viewer_type="tree",
-                    data={"error": msg, "hint": "MMKV store could not be read"},
+                    data={
+                        "error": "This MMKV store is AES-encrypted.",
+                        "hint": 'Use "Open as -> MMKV (Encrypted)..." and supply the key.',
+                    },
                     metadata={
-                        "Format": "MMKV Key-Value Store (parse failed)",
+                        "Format": "MMKV Key-Value Store (encrypted)",
                         "File size": f"{node.size:,} B",
-                        "Parse error": msg,
+                        "Encrypted": "yes",
                     },
                 )
-        finally:
-            for p in (tmp_path, tmp_path + ".crc"):
+            # The .crc file's vector-nonzero flag said "encrypted", but the
+            # store just read cleanly as plaintext -- trust the successful
+            # read over the flag, and say so explicitly rather than silently
+            # overriding it.
+            entries = plain_entries
+            false_positive_encrypted_flag = True
+        else:
+            tmp_dir = tempfile.mkdtemp(prefix="crush_mmkv_")
+            tmp_path = os.path.join(tmp_dir, node.name)
+            try:
+                with open(tmp_path, "wb") as f:
+                    f.write(raw)
+                if crc_bytes is not None:
+                    with open(tmp_path + ".crc", "wb") as f:
+                        f.write(crc_bytes)
                 try:
-                    os.remove(p)
+                    entries = read_entries(  # type: ignore[no-untyped-call]
+                        tmp_path, key=password, aes256=aes256
+                    )
+                except MMKVError as exc:
+                    msg = str(exc)
+                    if password is not None and "did not decrypt" in msg:
+                        raise WrongPasswordError(msg) from exc
+                    return ParseResult(
+                        viewer_type="tree",
+                        data={"error": msg, "hint": "MMKV store could not be read"},
+                        metadata={
+                            "Format": "MMKV Key-Value Store (parse failed)",
+                            "File size": f"{node.size:,} B",
+                            "Parse error": msg,
+                        },
+                    )
+            finally:
+                for p in (tmp_path, tmp_path + ".crc"):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+                try:
+                    os.rmdir(tmp_dir)
                 except OSError:
                     pass
-            try:
-                os.rmdir(tmp_dir)
-            except OSError:
-                pass
 
         records = _classify_entries(entries)
         live = sum(1 for r in records if r["state"] == "Live")
@@ -226,6 +267,12 @@ class MMKVParser(AbstractParser):
             meta["Meta file"] = "not found (.crc companion missing) — encryption status unverified"
         if password is not None:
             meta["Encrypted"] = "yes (decrypted)"
+        elif false_positive_encrypted_flag:
+            meta["Encrypted"] = (
+                "no — .crc meta file's vector field is non-zero, which normally "
+                "flags AES encryption, but the store read cleanly as plaintext "
+                "anyway, so that flag is treated as a false positive here"
+            )
 
         text_parts: list[str] = []
         for r in records:

--- a/crush/tests/test_mmkv_parser.py
+++ b/crush/tests/test_mmkv_parser.py
@@ -210,15 +210,39 @@ def _aes_cfb128_encrypt(data: bytes, key: bytes, iv: bytes) -> bytes:
 
 
 def test_encrypted_store_without_key_reports_encrypted_not_empty(tmp_path: Path) -> None:
-    payload = _store(_entry("a", _string_value("b")))
-    vector = bytes(range(1, 17))  # non-zero -> encrypted
-    crc = _meta_bytes(version=1, sequence=0, vector=vector)
-    node, vfs = _write_store(tmp_path, payload, crc=crc)
+    key = b"correct horse battery staple 12"[:16]
+    iv = bytes(range(16))
+    plaintext = _store(_entry("a", _string_value("secret")))
+    header, region = plaintext[:4], plaintext[4:]
+    ciphertext = header + _aes_cfb128_encrypt(region, key, iv)
+
+    crc = _meta_bytes(version=1, sequence=0, vector=iv)
+    node, vfs = _write_store(tmp_path, ciphertext, crc=crc)
 
     result = MMKVParser().parse(node, vfs)  # no password
     assert result.viewer_type == "tree"
     assert result.metadata["Encrypted"] == "yes"
     assert "records" not in result.data
+
+
+def test_high_meta_version_false_positive_encrypted_flag_does_not_block_plaintext_read(
+    tmp_path: Path,
+) -> None:
+    """Regression: a real react-native-mmkv store's .crc file had a non-zero
+    vector (meta version 61, far outside the 1-4 range this struct layout
+    has been verified against) even though the store's own data was
+    demonstrably plaintext (readable JSON, hundreds of correctly-decoded
+    entries). Crush must not take the vector-nonzero flag at face value when
+    the store reads cleanly as plaintext anyway -- confirm before refusing."""
+    payload = _store(_entry("a", _string_value("b")), _entry("c", _string_value("d")))
+    vector = bytes(range(1, 17))  # non-zero, would normally mean "encrypted"
+    crc = _meta_bytes(version=61, sequence=0, vector=vector)
+    node, vfs = _write_store(tmp_path, payload, crc=crc)
+
+    result = MMKVParser().parse(node, vfs)  # no password
+    assert result.data["records"][0]["decoded"] == "b"
+    assert result.data["records"][1]["decoded"] == "d"
+    assert "false positive" in result.metadata["Encrypted"]
 
 
 def test_encrypted_store_with_correct_key_decrypts(tmp_path: Path) -> None:

--- a/crush/tests/test_table_viewer.py
+++ b/crush/tests/test_table_viewer.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 import sqlite3
+import struct
 from pathlib import Path
 
 from PySide6.QtCore import QModelIndex, Qt
 
-from crush.viewers.table_viewer import TableViewer
+from crush.viewers.table_viewer import TableViewer, _format_wal_frame_content
 
 
 def _make_viewer() -> TableViewer:
@@ -103,6 +104,26 @@ def test_switching_tables_clears_stale_cell_detail_box(qapp) -> None:
     assert tv._cell_detail_label.text() == "—  No cell selected"
 
 
+def test_switching_to_plain_table_clears_stale_sql_status(qapp) -> None:
+    """Same bug class as #73, found in a fourth spot: the status line below
+    the SQL box (e.g. WAL Frames' "double-click to open in hex viewer" hint,
+    or Freelist Recovery's carve summary) is tab-specific but was never
+    cleared on switch -- a plain table's own loader never touches it, so it
+    kept describing whichever generated tab was visited last."""
+    data = {
+        "t1": {"columns": ["id", "data"], "rows": [[1, "alpha"]]},
+    }
+    tv = TableViewer(data, source_name="mydb.sqlite")
+
+    tv._sql_status.setStyleSheet("color: red;")
+    tv._sql_status.setText("Error scanning freelist pages: boom")
+
+    tv._load_table("t1")
+
+    assert tv._sql_status.text() == ""
+    assert tv._sql_status.styleSheet() == ""
+
+
 def test_freelist_table_filter_change_clears_stale_cell_detail_box(qapp) -> None:
     """Same bug class as #73, found in a second spot: switching the Freelist
     Recovery tab's "View as" filter bypasses _load_table entirely, so it
@@ -142,6 +163,239 @@ def test_running_query_clears_stale_cell_detail_box(qapp, tmp_path: Path) -> Non
 
     assert tv._cell_detail_view.toPlainText() == ""
     assert tv._cell_detail_label.text() == "—  No cell selected"
+
+
+def test_format_wal_frame_content_uses_real_column_names() -> None:
+    rows = [(1, ["alice", 30]), (2, ["bob", 25])]
+    text = _format_wal_frame_content(rows, ["name", "age"])
+    assert text == "1: [name=alice, age=30]; 2: [name=bob, age=25]"
+
+
+def test_format_wal_frame_content_falls_back_to_positional_on_column_mismatch() -> None:
+    """No column-name list, or one whose length doesn't match the decoded
+    row's value count (unknown/stale table mapping) — show plain values
+    rather than misaligning them with the wrong names."""
+    rows = [(1, ["x", "y", "z"])]
+    assert _format_wal_frame_content(rows, []) == "1: [x, y, z]"
+    assert _format_wal_frame_content(rows, ["only_one_col"]) == "1: [x, y, z]"
+
+
+def _make_live_wal_db(path: Path) -> sqlite3.Connection:
+    """Create a real WAL-mode DB with a committed frame still sitting in the
+    -wal file. Returns the writer connection -- keep it open for the rest of
+    the test, since closing the last connection to a WAL-mode database
+    checkpoints and removes the -wal file (wal_autocheckpoint=0 only stops
+    the *automatic* per-commit checkpoint, not the close-time one)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT)")
+    conn.commit()
+    conn.execute("INSERT INTO messages (body) VALUES ('hello-wal-content')")
+    conn.commit()
+    return conn
+
+
+def test_wal_frames_content_column_decodes_row(qapp, tmp_path: Path) -> None:
+    """The WAL Frames tab's Content column should decode a frame's page and
+    show the actual row values, using real column names for a page mapped
+    to a known table."""
+    db_path = tmp_path / "live.db"
+    writer = _make_live_wal_db(db_path)
+    try:
+        data = {
+            "__db_path": str(db_path),
+            "messages": {"columns": ["id", "body"], "rows": [[1, "hello-wal-content"]]},
+        }
+        tv = TableViewer(data, source_name="live.db")
+        tv._load_wal_frames()
+
+        model = tv._source_model
+        headers = [
+            model.headerData(c, Qt.Orientation.Horizontal) for c in range(model.columnCount())
+        ]
+        assert "Content" in headers
+        content_col = headers.index("Content")
+
+        contents = [model.item(r, content_col).text() for r in range(model.rowCount())]
+        assert any("hello-wal-content" in c for c in contents)
+        assert any("body=hello-wal-content" in c for c in contents)
+    finally:
+        writer.close()
+
+
+def _make_dropped_table_db(path: Path) -> None:
+    """Create a DB, fill a table across multiple pages, then drop it.
+
+    DROP TABLE frees the table's pages onto the freelist; with
+    secure_delete=OFF and no VACUUM, everything but the first freed page
+    (which gets overwritten with trunk bookkeeping) keeps its original
+    table-leaf bytes, so the freed rows are still carveable. Mirrors the
+    fixture in test_sqlite_freelist.py, but written to a real path (not a
+    NamedTemporaryFile) so a TableViewer can open it as __db_path.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA page_size=1024")
+    conn.execute("PRAGMA auto_vacuum=NONE")
+    conn.execute("PRAGMA secure_delete=OFF")
+    conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT)")
+    padding = "x" * 400
+    for i in range(30):
+        conn.execute("INSERT INTO messages (body) VALUES (?)", (f"secret-{i}-{padding}",))
+    conn.commit()
+    conn.execute("DROP TABLE messages")
+    conn.commit()
+    conn.close()
+
+
+def test_freelist_recovery_tab_carves_dropped_table_rows(qapp, tmp_path: Path) -> None:
+    """End-to-end regression guard: a dropped table's freed pages still carry
+    old row data (secure_delete=OFF, no VACUUM), so the Freelist Recovery tab
+    must show carved rows rather than "0 rows carved". The core carving
+    functions already have unit tests in test_sqlite_freelist.py; this covers
+    the TableViewer wiring on top (schema lookup, model population, status
+    text) that those don't touch."""
+    db_path = tmp_path / "dropped.db"
+    _make_dropped_table_db(db_path)
+
+    tv = TableViewer({"__db_path": str(db_path)}, source_name="dropped.db")
+    tv._freelist_cache = tv._get_freelist_data()  # precompute -> fast path, no bg thread
+    tv._load_freelist_recovery()
+
+    model = tv._source_model
+    cell_texts = [
+        model.item(r, c).text()
+        for r in range(model.rowCount())
+        for c in range(model.columnCount())
+        if model.item(r, c) is not None
+    ]
+    assert any("secret-" in t for t in cell_texts)
+    assert "0 rows carved" not in tv._row_count_label.text()
+
+
+def test_freeblocks_all_zero_data_shown_explicitly(qapp) -> None:
+    """A freeblock whose leftover bytes are all zero (secure_delete was on,
+    or the space was never written before being linked into the freeblock)
+    decodes fine but renders as an invisible blank cell -- indistinguishable
+    from "nothing here" even though Size (B) shows a real freeblock. The
+    Data column must say so explicitly instead of looking empty."""
+    tv = _make_viewer()
+    tv._reset_source_model()
+    freeblocks = [{"page": 2, "offset": 100, "size": 20, "data": b"\x00" * 16}]
+    tv._populate_freeblocks_table(freeblocks, {}, set())
+
+    model = tv._source_model
+    headers = [
+        model.headerData(c, Qt.Orientation.Horizontal) for c in range(model.columnCount())
+    ]
+    data_col = headers.index("Data")
+    assert model.item(0, data_col).text() == "(all zero — 16 B)"
+
+
+def test_freeblocks_nonzero_data_still_shown_as_text(qapp) -> None:
+    """Regression guard alongside the all-zero case above: real leftover
+    content must still render as plain decoded text, not the placeholder."""
+    tv = _make_viewer()
+    tv._reset_source_model()
+    freeblocks = [{"page": 2, "offset": 100, "size": 20, "data": b"secret-payload"}]
+    tv._populate_freeblocks_table(freeblocks, {}, set())
+
+    model = tv._source_model
+    headers = [
+        model.headerData(c, Qt.Orientation.Horizontal) for c in range(model.columnCount())
+    ]
+    data_col = headers.index("Data")
+    assert model.item(0, data_col).text() == "secret-payload"
+
+
+def test_freelist_recovery_tab_always_present(qapp, tmp_path: Path) -> None:
+    """Regression: the Freelist Recovery tab used to be added to the table
+    combo only if PRAGMA freelist_count (read live, through the connection)
+    was nonzero at construction time -- inconsistent with Freeblocks/
+    Unallocated, which are always present and just report "nothing found".
+    A DB with no freed pages at all must still show the tab."""
+    db_path = tmp_path / "clean.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    tv = TableViewer({"__db_path": str(db_path)}, source_name="clean.db")
+    items = [tv._table_combo.itemText(i) for i in range(tv._table_combo.count())]
+    assert tv._freelist_label in items
+
+
+def test_freelist_recovery_sees_pages_freed_only_in_uncheckpointed_wal(
+    qapp, tmp_path: Path
+) -> None:
+    """Regression: walk_freelist_pages()/carve_freelist_rows() used to read
+    only the base file's raw bytes, completely ignoring a live -wal
+    sidecar. A DROP TABLE recorded only in the WAL (wal_autocheckpoint=0, no
+    checkpoint yet) updates the freelist header and frees pages *only*
+    inside not-yet-checkpointed WAL frames -- a plain base-file scan sees
+    the pre-drop header (first_trunk=0) and reports "No freelist pages
+    found" despite a live connection's PRAGMA freelist_count already being
+    nonzero. This is exactly the inconsistency a user hit in practice
+    (tab shown -- because __init__ checks freelist_count live -- but the
+    scan itself came back empty)."""
+    db_path = tmp_path / "live.db"
+    writer = sqlite3.connect(str(db_path))
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA page_size=1024")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("PRAGMA secure_delete=OFF")
+        writer.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT)")
+        writer.commit()
+        padding = "x" * 400
+        for i in range(30):
+            writer.execute(
+                "INSERT INTO messages (body) VALUES (?)", (f"secret-{i}-{padding}",)
+            )
+        writer.commit()
+        writer.execute("DROP TABLE messages")
+        writer.commit()
+
+        # Sanity check on the premise: raw base-file header must indeed
+        # still show no freelist (that's what makes this a WAL-only state).
+        raw_header = db_path.read_bytes()[:100]
+        assert struct.unpack_from(">I", raw_header, 32)[0] == 0
+
+        tv = TableViewer({"__db_path": str(db_path)}, source_name="live.db")
+        entries, carved = tv._get_freelist_data()
+        assert entries
+        assert carved
+        assert any(
+            "secret-" in v
+            for c in carved
+            for _rowid, values in c["rows"]
+            for v in values
+            if isinstance(v, str)
+        )
+    finally:
+        writer.close()
+
+
+def test_freelist_recovery_tab_explains_zero_carved_rows(qapp, tmp_path: Path) -> None:
+    """When freed pages exist but genuinely hold nothing recoverable (e.g.
+    secure_delete was on at write time), the status text must say so
+    explicitly rather than leaving a bare "0 rows carved" that reads like a
+    broken feature."""
+    db_path = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA page_size=1024")
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    tv = TableViewer({"__db_path": str(db_path)}, source_name="empty.db")
+    # No real freelist needed to exercise this path -- feed one synthetic
+    # freed-page entry with no carved rows directly, bypassing the scan.
+    tv._freelist_cache = ([{"page": 2, "kind": "leaf"}], [])
+    tv._load_freelist_recovery()
+
+    assert "0 rows carved" in tv._row_count_label.text()
+    assert "not a parsing failure" in tv._sql_status.text()
 
 
 def test_open_bytes_with_format_requested_carries_metadata_dict(qapp) -> None:

--- a/crush/viewers/table_viewer.py
+++ b/crush/viewers/table_viewer.py
@@ -68,6 +68,7 @@ from crush.core.sqlite_freelist import (
 from crush.core.sqlite_unallocated import scan_database_unallocated
 from crush.core.sqlite_wal import (
     build_page_table_map,
+    build_wal_page_overlay,
     parse_table_leaf_page,
 )
 from crush.core.ts_decode import TS_FORMATS as _TS_FORMATS
@@ -201,6 +202,21 @@ def _wal_diag(db_path: "str | None", parser_diag: str = "") -> str:
     if magic not in _WAL_MAGIC:
         return f"invalid magic 0x{magic:08x}"
     return f"WAL ok (size={size} B, magic=0x{magic:08x}) — frames list empty"
+
+
+def _format_wal_frame_content(rows: list[tuple[int, list[Any]]], col_names: list[str]) -> str:
+    """Render decoded (rowid, values) tuples from a WAL frame's page as one
+    compact string for the Content column — real column names when the
+    frame's page maps to a known table with a matching column count,
+    positional otherwise."""
+    parts: list[str] = []
+    for rowid, values in rows:
+        if col_names and len(col_names) == len(values):
+            body = ", ".join(f"{c}={v}" for c, v in zip(col_names, values))
+        else:
+            body = ", ".join(str(v) for v in values)
+        parts.append(f"{rowid}: [{body}]")
+    return "; ".join(parts)
 
 
 class _SqlHighlighter(QSyntaxHighlighter):
@@ -521,6 +537,9 @@ class TableViewer(QWidget):
         self._wal_frames_cache: list[dict] | None = None
         self._wal_page_size: int = 0
         self._db_page_size: int = 0
+        self._wal_data_loaded = False
+        self._wal_data_cache: bytes | None = None
+        self._wal_page_overlay_cache: dict[int, bytes] | None = None
         self._freelist_cache: tuple[list[dict], list[dict]] | None = None
         self._freelist_render_state: (
             tuple[list[dict], list[dict], dict[str, list[tuple[str, str]]]] | None
@@ -540,8 +559,7 @@ class TableViewer(QWidget):
                     self._table_combo.addItem(self._db_info_label)
                     if self._db_path and Path(str(self._db_path) + "-wal").exists():
                         self._table_combo.addItem(self._wal_label)
-                    if self._db_path and self._has_freelist_pages():
-                        self._table_combo.addItem(self._freelist_label)
+                    self._table_combo.addItem(self._freelist_label)
                     self._table_combo.addItem(self._freeblocks_label)
                     self._table_combo.addItem(self._unallocated_label)
                 self._table_combo.addItems(table_names)
@@ -769,6 +787,17 @@ class TableViewer(QWidget):
         # freshly loaded table yet, so the box should say so too (#73).
         self._cell_detail_label.setText("—  No cell selected")
         self._cell_detail_view.setPlainText("")
+
+        # Same bug class: the status line below the SQL box is tab-specific
+        # (e.g. WAL Frames' "double-click to open in hex viewer", Freelist
+        # Recovery's carve summary) but was never cleared on switch, so it
+        # kept describing the *previous* tab after landing on a plain table
+        # -- which never sets it itself and so never overwrote the leftover
+        # text. Every generated tab sets its own status right after loading,
+        # so clearing here is always immediately superseded except for plain
+        # tables, which is exactly the case that needs it cleared.
+        self._sql_status.setText("")
+        self._sql_status.setStyleSheet("")
 
         # _activate_standard_model() itself turns dynamic sorting back on
         # (when leaving query-results mode), so it must run *before* it's
@@ -1308,7 +1337,7 @@ class TableViewer(QWidget):
         frames = self._get_wal_frames()
         self._reset_source_model()
         self._source_model.setHorizontalHeaderLabels(
-            ["Frame", "Page", "Transaction", "Status", "Table", "Offset (B)"]
+            ["Frame", "Page", "Transaction", "Status", "Table", "Offset (B)", "Content"]
         )
         if not frames:
             parser_diag = self._data.get("__wal_diag", "") if isinstance(self._data, dict) else ""
@@ -1325,9 +1354,33 @@ class TableViewer(QWidget):
             "WAL slack":   Qt.GlobalColor.darkGray,
         }
 
+        wal_data = self._get_wal_data()
+
+        schema_col_names: dict[str, list[str]] = {}
+        conn = self._ensure_db()
+        if conn is not None:
+            schema_col_names = {
+                name: [col for col, _aff in cols]
+                for name, cols in self._table_schema_columns(conn).items()
+            }
+
         for f in frames:
             color = _status_color.get(f["status"])
             table_name = self._page_table_map.get(f["page"], "—")
+
+            content_text = "—"
+            if f["salt_ok"] and wal_data is not None and self._wal_page_size:
+                page_start = f["offset"] + 24
+                page_bytes = wal_data[page_start: page_start + self._wal_page_size]
+                decoded = parse_table_leaf_page(page_bytes, page_size=self._wal_page_size)
+                if decoded is None:
+                    content_text = "(not a leaf page)"
+                elif not decoded:
+                    content_text = "(empty leaf page)"
+                else:
+                    content_text = _format_wal_frame_content(
+                        decoded, schema_col_names.get(table_name, [])
+                    )
 
             def _item(text: str, sort_val: object = None, _c: object = color) -> QStandardItem:
                 it = QStandardItem(text)
@@ -1345,6 +1398,7 @@ class TableViewer(QWidget):
                 _item(f["status"]),
                 _item(table_name),
                 _item(str(f["offset"]),                  f["offset"]),
+                _item(content_text),
             ])
 
         self._resize_and_cap()
@@ -1357,7 +1411,43 @@ class TableViewer(QWidget):
             if n:
                 parts.append(f"{n} {status.lower()}")
         self._row_count_label.setText(f"({', '.join(parts)})")
-        self._sql_status.setText("Double-click a row to open the raw page in the hex viewer")
+        self._sql_status.setText(
+            "Double-click a row to open the raw page in the hex viewer — "
+            "click a Content cell to see the full decoded value below"
+        )
+
+    def _get_wal_data(self) -> bytes | None:
+        """Return (and cache) the raw -wal sidecar's bytes, or None if there
+        isn't one. Shared by every caller that needs the live WAL's content
+        (as opposed to _get_wal_frames()'s classified, page-size-validated
+        frame list) so the file is only read once per viewer instance."""
+        if self._wal_data_loaded:
+            return self._wal_data_cache
+        self._wal_data_loaded = True
+        if self._db_path is not None:
+            try:
+                self._wal_data_cache = Path(str(self._db_path) + "-wal").read_bytes()
+            except OSError:
+                self._wal_data_cache = None
+        return self._wal_data_cache
+
+    def _get_wal_page_overlay(self) -> dict[int, bytes]:
+        """Return (and cache) {page_num: bytes} for whatever the live -wal
+        file has committed but not yet checkpointed into the base file.
+
+        Every SQLite-recovery scanner (sqlite_freelist, sqlite_freeblocks,
+        sqlite_unallocated) reads the base file's raw bytes directly rather
+        than through sqlite3, so none of them see WAL content on their own —
+        a page whose current, forensically-relevant content sits only in a
+        not-yet-checkpointed WAL frame would otherwise look stale, missing,
+        or (for the freelist header itself) simply absent even though
+        PRAGMA freelist_count on a live connection already reports it.
+        """
+        if self._wal_page_overlay_cache is not None:
+            return self._wal_page_overlay_cache
+        page_size = self._get_page_size()
+        self._wal_page_overlay_cache = build_wal_page_overlay(self._get_wal_data(), page_size)
+        return self._wal_page_overlay_cache
 
     def _get_page_size(self) -> int:
         """Return (and cache) the database's page size via PRAGMA."""
@@ -1373,16 +1463,6 @@ class TableViewer(QWidget):
             self._db_page_size = 0
         return self._db_page_size
 
-    def _has_freelist_pages(self) -> bool:
-        conn = self._ensure_db()
-        if conn is None:
-            return False
-        try:
-            row = conn.execute("PRAGMA freelist_count").fetchone()
-            return bool(row and row[0])
-        except Exception:
-            return False
-
     def _get_freelist_data(self) -> tuple[list[dict], list[dict]]:
         """Return (and cache) (freelist entries, carved leftover rows)."""
         if self._freelist_cache is not None:
@@ -1391,8 +1471,9 @@ class TableViewer(QWidget):
         if self._db_path is None or page_size == 0:
             self._freelist_cache = ([], [])
             return self._freelist_cache
-        entries = walk_freelist_pages(self._db_path, page_size)
-        carved = carve_freelist_rows(self._db_path, page_size, entries)
+        wal_pages = self._get_wal_page_overlay()
+        entries = walk_freelist_pages(self._db_path, page_size, wal_pages)
+        carved = carve_freelist_rows(self._db_path, page_size, entries, wal_pages)
         self._freelist_cache = (entries, carved)
         return self._freelist_cache
 
@@ -1657,18 +1738,29 @@ class TableViewer(QWidget):
                 f"({len(entries)} freelist pages, {n_pages_with_data} with recoverable data, "
                 f"{total_rows} rows carved)"
             )
-            self._sql_status.setText(
-                "Candidate tables are a heuristic match — the source table cannot be "
-                "determined with certainty from a freed page. ✓-marked candidates match on "
-                "both column count and value types (higher confidence); unmarked candidates "
-                "match column count only. Values spilling onto overflow "
-                "pages are reconstructed when those pages are still on the freelist "
-                "unmodified; otherwise shown as '<OVERFLOW>'. Double-click a row to open the "
-                "raw page in the hex viewer."
-            )
+            if total_rows == 0:
+                self._sql_status.setText(
+                    f"{len(entries)} freed page(s) found, but none still carry leftover "
+                    "cell data — not a parsing failure. Either a later allocation already "
+                    "overwrote them, or secure_delete was enabled at write time."
+                )
+            else:
+                self._sql_status.setText(
+                    "Candidate tables are a heuristic match — the source table cannot be "
+                    "determined with certainty from a freed page. ✓-marked candidates match on "
+                    "both column count and value types (higher confidence); unmarked candidates "
+                    "match column count only. Values spilling onto overflow "
+                    "pages are reconstructed when those pages are still on the freelist "
+                    "unmodified; otherwise shown as '<OVERFLOW>'. Double-click a row to open the "
+                    "raw page in the hex viewer."
+                )
 
     def _get_page_table_map(self) -> dict[int, str]:
-        """Return (and cache) {page_num: table_name}, independent of WAL presence."""
+        """Return (and cache) {page_num: table_name}, WAL-aware like
+        _get_wal_frames() builds it -- unlike that method, this one is
+        reachable without ever visiting the WAL Frames tab first (Freeblocks
+        and Unallocated Space use it too), so it has to fetch the WAL data
+        itself rather than assume _page_table_map was already populated."""
         if self._page_table_map:
             return self._page_table_map
         conn = self._ensure_db()
@@ -1676,7 +1768,7 @@ class TableViewer(QWidget):
         if conn is None or page_size == 0:
             return {}
         try:
-            self._page_table_map = build_page_table_map(conn, None, page_size)
+            self._page_table_map = build_page_table_map(conn, self._get_wal_data(), page_size)
         except Exception:
             self._page_table_map = {}
         return self._page_table_map
@@ -1689,7 +1781,9 @@ class TableViewer(QWidget):
         if self._db_path is None or page_size == 0:
             self._freeblocks_cache = []
             return self._freeblocks_cache
-        self._freeblocks_cache = scan_database_freeblocks(self._db_path, page_size)
+        self._freeblocks_cache = scan_database_freeblocks(
+            self._db_path, page_size, self._get_wal_page_overlay()
+        )
         return self._freeblocks_cache
 
     def _load_freeblocks(self) -> None:
@@ -1776,7 +1870,20 @@ class TableViewer(QWidget):
                     origin = "Freelist"
                 else:
                     origin = "—"
-                text = fb["data"].decode("utf-8", errors="replace")
+                raw = fb["data"]
+                if not raw:
+                    text = ""
+                elif not any(raw):
+                    # A string of NUL bytes decodes fine but renders as an
+                    # invisible blank cell in the table -- indistinguishable
+                    # from "nothing here" even though Size (B) shows this
+                    # freeblock is real. Say so explicitly instead (this is
+                    # itself a legitimate, forensically meaningful result:
+                    # e.g. secure_delete was on, or the space was never
+                    # written to before being linked into the freeblock).
+                    text = f"(all zero — {len(raw)} B)"
+                else:
+                    text = raw.decode("utf-8", errors="replace")
 
                 items = [
                     QStandardItem(str(page)),
@@ -1806,7 +1913,9 @@ class TableViewer(QWidget):
         if self._db_path is None or page_size == 0:
             self._unallocated_cache = []
             return self._unallocated_cache
-        self._unallocated_cache = scan_database_unallocated(self._db_path, page_size)
+        self._unallocated_cache = scan_database_unallocated(
+            self._db_path, page_size, self._get_wal_page_overlay()
+        )
         return self._unallocated_cache
 
     def _load_unallocated_space(self) -> None:
@@ -1959,7 +2068,9 @@ class TableViewer(QWidget):
                 page_num = int(page_item.text())
             except ValueError:
                 return
-            page_bytes = _read_freelist_page(self._db_path, page_num, page_size)
+            page_bytes = _read_freelist_page(
+                self._db_path, page_num, page_size, self._get_wal_page_overlay()
+            )
             if page_bytes:
                 self.open_bytes_requested.emit(page_bytes, f"Freelist page {page_num}")
             return
@@ -1978,7 +2089,9 @@ class TableViewer(QWidget):
                 page_num = int(page_item.text())
             except ValueError:
                 return
-            page_bytes = _read_freelist_page(self._db_path, page_num, page_size)
+            page_bytes = _read_freelist_page(
+                self._db_path, page_num, page_size, self._get_wal_page_overlay()
+            )
             if page_bytes:
                 self.open_bytes_requested.emit(page_bytes, f"Page {page_num} (freeblock)")
             return
@@ -1997,7 +2110,9 @@ class TableViewer(QWidget):
                 page_num = int(page_item.text())
             except ValueError:
                 return
-            page_bytes = _read_freelist_page(self._db_path, page_num, page_size)
+            page_bytes = _read_freelist_page(
+                self._db_path, page_num, page_size, self._get_wal_page_overlay()
+            )
             if page_bytes:
                 self.open_bytes_requested.emit(page_bytes, f"Page {page_num} (unallocated space)")
             return


### PR DESCRIPTION
…rs and MMKV false-positive encryption flag

- WAL Frames tab gets a Content column, decoding each frame's page into its   actual row values (real column names when the page maps to a known table).
- Freelist Recovery, Freeblocks, and Unallocated Space scanners (and page→table   attribution) read only the frozen base file, ignoring a live not-yet-
  checkpointed -wal sidecar — a delete/drop recorded only in the WAL looked  like nothing was ever freed. Now WAL-aware via a shared page overlay.
- Freelist Recovery tab was only shown when a live PRAGMA reported freed  pages, unlike Freeblocks/Unallocated (always shown); now always shown too,  with an explicit status message for "nothing recoverable" vs "no freed  pages at all".
- Freeblocks' Data column rendered an all-zero freeblock as an apparently  empty cell (NUL bytes are invisible); now states "(all zero — N B)".
- SQL box's status line kept a previous tab's message after switching to a  plain table (same bug class as #73).
- MMKV parser trusted a store's .crc "non-zero vector" field as proof of AES  encryption — confirmed false-positive on a real react-native-mmkv store  with demonstrably plaintext data. Now only reports "encrypted" when the  store genuinely fails to read as plaintext.