### PR TITLE
feat: embedded, bidirectional Hex pane for SQLite/Realm Table Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Crush will be documented in this file.
 
 ### New Features
 
+- Protobuf Viewer (schema-based and schema-less) and the Plist/XML Tree Viewer now have an optional embedded Hex pane (**Show Hex**), bidirectionally synced with the decoded tree: selecting a field highlights its exact byte range in the hex view, and clicking a byte selects the matching field. ([@JamesHabben](https://github.com/JamesHabben), [#83](https://github.com/kalink0/crush-forensics/pull/83))
+- SQLite Table Viewer (and Realm's table view, which shares it) gets the same **Show Hex** pane, extended to per-cell precision: selecting a cell highlights its row and that specific column's on-disk bytes; a row whose current version is only in a not-yet-checkpointed `-wal` frame switches the pane to that file instead of the base file's stale bytes.
 - SQLite Table Viewer's WAL Frames tab now has a Content column, decoding each frame's page into its actual row values (with real column names when the page maps to a known table) instead of only frame/page/status metadata.
 - SEGB/Biome Viewer's Properties panel now shows the file's Biome stream name, derived from its path. Right-clicking any folder now offers **Send Biome Streams to Peach…**, which recursively finds SEGB files by content (not by directory-naming convention, so it works under any Biome root — macOS or iOS), confirms via a checklist, then hands the selected files to peach as one source with their original directory structure preserved — the first step toward a Biome tagging rule pack in peach itself.
 

--- a/crush/core/sqlite_wal.py
+++ b/crush/core/sqlite_wal.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import sqlite3
 import struct
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal, overload
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +142,63 @@ def _decode_record(payload: bytes) -> list[Any]:
     return values
 
 
+def _serial_type_len(stype: int) -> int:
+    """Return the on-disk byte length of a SQLite record serial type.
+
+    A standalone length table, not reused *by* _decode_record() itself (that
+    function's per-branch unpacking is left untouched to avoid any risk of
+    changing its already-shipped decoding behavior) -- kept here purely so
+    _record_field_ranges() below can locate each column's bytes without
+    re-decoding its value. Must stay in sync with _decode_record()'s branches
+    (see https://www.sqlite.org/fileformat2.html#record_format).
+    """
+    if stype in (0, 8, 9):
+        return 0
+    if stype == 1:
+        return 1
+    if stype == 2:
+        return 2
+    if stype == 3:
+        return 3
+    if stype == 4:
+        return 4
+    if stype == 5:
+        return 6
+    if stype in (6, 7):
+        return 8
+    if stype >= 12 and stype % 2 == 0:
+        return (stype - 12) // 2
+    if stype >= 13 and stype % 2 == 1:
+        return (stype - 13) // 2
+    return 0  # reserved serial types 10, 11
+
+
+def _record_field_ranges(payload: bytes) -> list[tuple[int, int]]:
+    """Return each column's (start, end) byte range *within payload* --
+    companion to _decode_record(), which returns values but discards where
+    each field's bytes actually live. Used by locate_cell() (below) to
+    highlight one specific column's on-disk bytes.
+    """
+    if not payload:
+        return []
+
+    hdr_size, consumed = _read_varint(payload, 0)
+    pos = consumed
+    serial_types: list[int] = []
+    while pos < hdr_size:
+        stype, n = _read_varint(payload, pos)
+        serial_types.append(stype)
+        pos += n
+
+    ranges: list[tuple[int, int]] = []
+    body_pos = hdr_size
+    for stype in serial_types:
+        length = _serial_type_len(stype)
+        ranges.append((body_pos, body_pos + length))
+        body_pos += length
+    return ranges
+
+
 # ---------------------------------------------------------------------------
 # Table leaf page parser
 # ---------------------------------------------------------------------------
@@ -167,6 +225,39 @@ def _payload_inline_size(payload_size: int, usable_size: int) -> int:
     return K if K <= X else M
 
 
+def _follow_overflow_chain_ex(
+    first_page: int,
+    remaining: int,
+    usable_size: int,
+    overflow_reader: Callable[[int], bytes | None],
+    max_pages: int = 10_000,
+) -> tuple[bytes, list[tuple[int, int]]]:
+    """Like _follow_overflow_chain(), but also returns the (page_num,
+    bytes_taken) for each overflow page actually visited, in chain order --
+    needed to map a reconstructed payload's logical byte positions back to
+    their physical page/offset (see locate_cell()).
+    """
+    collected = bytearray()
+    segments: list[tuple[int, int]] = []
+    page_num = first_page
+    visited: set[int] = set()
+    per_page_capacity = usable_size - 4
+
+    while page_num and remaining > 0 and page_num not in visited and len(visited) < max_pages:
+        visited.add(page_num)
+        page = overflow_reader(page_num)
+        if page is None or len(page) < 4:
+            break
+        next_page = struct.unpack_from(">I", page, 0)[0]
+        take = min(remaining, per_page_capacity, len(page) - 4)
+        collected.extend(page[4:4 + take])
+        segments.append((page_num, take))
+        remaining -= take
+        page_num = next_page
+
+    return bytes(collected), segments
+
+
 def _follow_overflow_chain(
     first_page: int,
     remaining: int,
@@ -182,31 +273,52 @@ def _follow_overflow_chain(
     pages (e.g. other pages still confirmed on the freelist) should return
     None for anything else rather than risk splicing in unrelated live data.
     """
-    collected = bytearray()
-    page_num = first_page
-    visited: set[int] = set()
-    per_page_capacity = usable_size - 4
-
-    while page_num and remaining > 0 and page_num not in visited and len(visited) < max_pages:
-        visited.add(page_num)
-        page = overflow_reader(page_num)
-        if page is None or len(page) < 4:
-            break
-        next_page = struct.unpack_from(">I", page, 0)[0]
-        take = min(remaining, per_page_capacity, len(page) - 4)
-        collected.extend(page[4:4 + take])
-        remaining -= take
-        page_num = next_page
-
-    return bytes(collected)
+    data, _segments = _follow_overflow_chain_ex(
+        first_page, remaining, usable_size, overflow_reader, max_pages
+    )
+    return data
 
 
+@dataclass
+class RowByteLayout:
+    """Physical layout of one table-leaf cell, describing where its bytes
+    actually live so a decoded row/column can be mapped back to exact
+    on-disk ranges (see locate_cell()). All positions except
+    *overflow_segments* (page_num, bytes_taken) are relative to the page
+    passed to parse_table_leaf_page(); overflow pages are looked up
+    separately by the caller, which is the only one that knows whether a
+    given page number currently lives in the base file or a -wal frame.
+    """
+    page_local_range: tuple[int, int]        # (cell_offset, end-of-inline-payload) within `page`
+    payload_start_in_page: int               # where the inline payload itself begins, within `page`
+    inline_payload_size: int
+    overflow_segments: list[tuple[int, int]]  # (overflow_page_num, bytes_taken), in chain order
+    column_logical_ranges: list[tuple[int, int]]  # per column, within the logical (inline+overflow) payload
+
+
+@overload
 def parse_table_leaf_page(
     page: bytes,
     *,
     page_size: int = 0,
     overflow_reader: Callable[[int], bytes | None] | None = None,
-) -> list[tuple[int, list[Any]]] | None:
+    want_ranges: Literal[False] = False,
+) -> list[tuple[int, list[Any]]] | None: ...
+@overload
+def parse_table_leaf_page(
+    page: bytes,
+    *,
+    page_size: int = 0,
+    overflow_reader: Callable[[int], bytes | None] | None = None,
+    want_ranges: Literal[True],
+) -> list[tuple[int, list[Any], RowByteLayout]] | None: ...
+def parse_table_leaf_page(
+    page: bytes,
+    *,
+    page_size: int = 0,
+    overflow_reader: Callable[[int], bytes | None] | None = None,
+    want_ranges: bool = False,
+) -> list[tuple[int, list[Any]]] | list[tuple[int, list[Any], RowByteLayout]] | None:
     """Parse a SQLite table-leaf page (type 0x0D).
 
     Returns a list of (rowid, [values]) tuples, or None if the page is not a
@@ -216,6 +328,10 @@ def parse_table_leaf_page(
     *page_size* and *overflow_reader* to reconstruct values that spill onto
     overflow pages — *overflow_reader(page_num)* should return that page's
     raw bytes, or None if it can't be trusted/read.
+
+    Pass *want_ranges=True* to additionally get each row's on-disk byte
+    layout back — returns (rowid, values, RowByteLayout) tuples instead.
+    Existing callers that don't pass it are unaffected.
     """
     if len(page) < 8:
         return None
@@ -231,6 +347,7 @@ def parse_table_leaf_page(
     # Cell pointer array starts at offset 8 (table-leaf has no rightmost-pointer)
     ptr_area_start = 8
     rows: list[tuple[int, list[Any]]] = []
+    row_layouts: list[RowByteLayout] = []
     usable_size = page_size or len(page)
 
     for i in range(cell_count):
@@ -252,19 +369,34 @@ def parse_table_leaf_page(
             payload = bytearray(page[pos:pos + inline_size])
 
             remaining = payload_size - inline_size
+            overflow_segments: list[tuple[int, int]] = []
             if remaining > 0 and overflow_reader is not None:
                 overflow_ptr_off = pos + inline_size
                 if overflow_ptr_off + 4 <= len(page):
                     next_page = struct.unpack_from(">I", page, overflow_ptr_off)[0]
-                    payload.extend(
-                        _follow_overflow_chain(next_page, remaining, usable_size, overflow_reader)
+                    overflow_bytes, overflow_segments = _follow_overflow_chain_ex(
+                        next_page, remaining, usable_size, overflow_reader
                     )
+                    payload.extend(overflow_bytes)
 
             values = _decode_record(bytes(payload))
             rows.append((rowid, values))
+            if want_ranges:
+                row_layouts.append(RowByteLayout(
+                    page_local_range=(cell_offset, pos + inline_size),
+                    payload_start_in_page=pos,
+                    inline_payload_size=inline_size,
+                    overflow_segments=overflow_segments,
+                    column_logical_ranges=_record_field_ranges(bytes(payload)),
+                ))
         except Exception:
             continue
 
+    if want_ranges:
+        return [
+            (row_rowid, row_values, layout)
+            for (row_rowid, row_values), layout in zip(rows, row_layouts)
+        ]
     return rows
 
 
@@ -283,6 +415,36 @@ def get_page_type(page: bytes) -> int | None:
 _WAL_MAGIC = (0x377F0682, 0x377F0683)
 
 
+def build_wal_page_index(wal_data: bytes | None, page_size: int) -> dict[int, tuple[int, bytes]]:
+    """Return {page_num: (data_offset, latest committed page bytes)} from a
+    WAL file's salt-valid frames -- like build_wal_page_overlay() below, but
+    also keeps each page's absolute byte offset *within wal_data* (the
+    frame's data section, right after its 24-byte header). locate_cell()
+    needs that offset to open the -wal file's own Hex view at the right
+    spot, not just to know a page's current content.
+    """
+    index: dict[int, tuple[int, bytes]] = {}
+    if not wal_data or not page_size or len(wal_data) < 32:
+        return index
+    magic = struct.unpack_from(">I", wal_data, 0)[0]
+    if magic not in _WAL_MAGIC:
+        return index
+    salt1 = struct.unpack_from(">I", wal_data, 16)[0]
+    salt2 = struct.unpack_from(">I", wal_data, 20)[0]
+    frame_size = 24 + page_size
+    offset = 32
+    # Collect last valid frame per page (active)
+    while offset + frame_size <= len(wal_data):
+        pn  = struct.unpack_from(">I", wal_data, offset)[0]
+        fs1 = struct.unpack_from(">I", wal_data, offset + 8)[0]
+        fs2 = struct.unpack_from(">I", wal_data, offset + 12)[0]
+        if fs1 == salt1 and fs2 == salt2:
+            data_offset = offset + 24
+            index[pn] = (data_offset, wal_data[data_offset: data_offset + page_size])
+        offset += frame_size
+    return index
+
+
 def build_wal_page_overlay(wal_data: bytes | None, page_size: int) -> dict[int, bytes]:
     """Return {page_num: latest committed page bytes} from a WAL file's
     salt-valid frames.
@@ -298,25 +460,7 @@ def build_wal_page_overlay(wal_data: bytes | None, page_size: int) -> dict[int, 
     changed. Passing this overlay's bytes for a page number, falling back to
     the base file otherwise, closes that gap without needing sqlite3 at all.
     """
-    wal_pages: dict[int, bytes] = {}
-    if not wal_data or not page_size or len(wal_data) < 32:
-        return wal_pages
-    magic = struct.unpack_from(">I", wal_data, 0)[0]
-    if magic not in _WAL_MAGIC:
-        return wal_pages
-    salt1 = struct.unpack_from(">I", wal_data, 16)[0]
-    salt2 = struct.unpack_from(">I", wal_data, 20)[0]
-    frame_size = 24 + page_size
-    offset = 32
-    # Collect last valid frame per page (active)
-    while offset + frame_size <= len(wal_data):
-        pn  = struct.unpack_from(">I", wal_data, offset)[0]
-        fs1 = struct.unpack_from(">I", wal_data, offset + 8)[0]
-        fs2 = struct.unpack_from(">I", wal_data, offset + 12)[0]
-        if fs1 == salt1 and fs2 == salt2:
-            wal_pages[pn] = wal_data[offset + 24: offset + 24 + page_size]
-        offset += frame_size
-    return wal_pages
+    return {pn: data for pn, (_offset, data) in build_wal_page_index(wal_data, page_size).items()}
 
 
 def build_page_table_map(
@@ -444,3 +588,319 @@ def _read_page(
         return data if len(data) == page_size else None
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Live row/cell → exact on-disk byte range ("Locate in Hex")
+# ---------------------------------------------------------------------------
+
+def _read_db_page(db_path: Path, page_num: int, page_size: int) -> bytes | None:
+    """Read one page directly from the base file. A small local copy of
+    sqlite_freelist.read_raw_page()'s logic rather than importing it --
+    sqlite_freelist.py already imports from this module, so importing back
+    would be circular.
+    """
+    if page_num < 1 or page_size <= 0:
+        return None
+    try:
+        with open(db_path, "rb") as fh:
+            fh.seek((page_num - 1) * page_size)
+            data = fh.read(page_size)
+    except OSError:
+        return None
+    return data if len(data) == page_size else None
+
+
+def _decompose_logical_range(
+    start: int, end: int, inline_size: int, overflow_segments: list[tuple[int, int]]
+) -> list[tuple[str, int, int, int]]:
+    """Split a payload-logical [start, end) range into physical pieces.
+
+    Each piece is either ("page", local_start, local_end, 0) -- bytes in the
+    inline portion, at the given offset *within the inline payload itself*
+    (callers add RowByteLayout.payload_start_in_page) -- or ("overflow",
+    local_start, local_end, page_num) -- bytes on one overflow page, local to
+    that page's own content area (i.e. already past its 4-byte next-pointer
+    header).
+    """
+    pieces: list[tuple[str, int, int, int]] = []
+    if start < end and start < inline_size:
+        seg_end = min(end, inline_size)
+        pieces.append(("page", start, seg_end, 0))
+    cursor = inline_size
+    for page_num, taken in overflow_segments:
+        seg_start = max(start, cursor)
+        seg_end = min(end, cursor + taken)
+        if seg_start < seg_end:
+            pieces.append(("overflow", seg_start - cursor, seg_end - cursor, page_num))
+        cursor += taken
+    return pieces
+
+
+def _resolve_pieces(
+    pieces: list[tuple[str, int, int, int]],
+    *,
+    payload_start_in_page: int,
+    page_file_offset: int,
+    home_file_kind: str,
+    page_locator: Callable[[int], tuple[str, int] | None],
+) -> list[tuple[int, int]]:
+    """Resolve decomposed pieces (see _decompose_logical_range) to absolute
+    file byte ranges, dropping any overflow piece that lives in a different
+    file (base vs -wal) than *home_file_kind* -- never splice bytes from the
+    wrong file into a single highlighted view.
+    """
+    out: list[tuple[int, int]] = []
+    for kind, seg_start, seg_end, page_num in pieces:
+        if kind == "page":
+            base = page_file_offset + payload_start_in_page
+            out.append((base + seg_start, base + seg_end))
+        else:
+            located = page_locator(page_num)
+            if located is None:
+                continue
+            file_kind, overflow_page_offset = located
+            if file_kind != home_file_kind:
+                continue
+            base = overflow_page_offset + 4  # skip the overflow page's next-pointer header
+            out.append((base + seg_start, base + seg_end))
+    return out
+
+
+@dataclass
+class CellLocation:
+    """Result of locate_cell(): where a live row (and, if requested, one of
+    its columns) currently lives on disk."""
+    file_kind: str                              # "base" or "wal"
+    row_ranges: list[tuple[int, int]]
+    column_ranges: list[tuple[int, int]] | None  # None if not requested/resolvable
+
+
+def _page_accessors(
+    db_path: Path, page_size: int, wal_index: dict[int, tuple[int, bytes]]
+) -> tuple[Callable[[int], tuple[str, int] | None], Callable[[int], bytes | None]]:
+    """Shared (page_locator, read_page) pair, preferring a page's -wal
+    version when one exists (i.e. resolving each page's *current* content)
+    -- used by locate_cell() and by locate_offset()'s "wal" mode."""
+
+    def page_locator(page_num: int) -> tuple[str, int] | None:
+        if page_num in wal_index:
+            offset, _data = wal_index[page_num]
+            return "wal", offset
+        if page_num >= 1:
+            return "base", (page_num - 1) * page_size
+        return None
+
+    def read_page(page_num: int) -> bytes | None:
+        if page_num in wal_index:
+            return wal_index[page_num][1]
+        return _read_db_page(db_path, page_num, page_size)
+
+    return page_locator, read_page
+
+
+def _raw_base_accessors(
+    db_path: Path, page_size: int
+) -> tuple[Callable[[int], tuple[str, int] | None], Callable[[int], bytes | None]]:
+    """Like _page_accessors(), but never consults the -wal file at all --
+    for locate_offset()'s "base" mode, where the caller (a Hex pane showing
+    the base file's own raw bytes, unmerged with any WAL frame) needs
+    ranges decoded strictly from what's actually at those offsets in the
+    base file, not from whichever version SQLite would currently prefer.
+    """
+
+    def page_locator(page_num: int) -> tuple[str, int] | None:
+        if page_num >= 1:
+            return "base", (page_num - 1) * page_size
+        return None
+
+    def read_page(page_num: int) -> bytes | None:
+        return _read_db_page(db_path, page_num, page_size)
+
+    return page_locator, read_page
+
+
+def _row_ranges_from_layout(
+    layout: RowByteLayout,
+    page_file_offset: int,
+    home_file_kind: str,
+    page_locator: Callable[[int], tuple[str, int] | None],
+) -> list[tuple[int, int]]:
+    cell_start, cell_end = layout.page_local_range
+    row_ranges = [(page_file_offset + cell_start, page_file_offset + cell_end)]
+    for seg_page_num, seg_len in layout.overflow_segments:
+        seg_located = page_locator(seg_page_num)
+        if seg_located is None:
+            continue
+        seg_file_kind, seg_file_offset = seg_located
+        if seg_file_kind != home_file_kind:
+            continue
+        row_ranges.append((seg_file_offset + 4, seg_file_offset + 4 + seg_len))
+    return row_ranges
+
+
+def _column_ranges_from_layout(
+    layout: RowByteLayout,
+    column_index: int,
+    page_file_offset: int,
+    home_file_kind: str,
+    page_locator: Callable[[int], tuple[str, int] | None],
+) -> list[tuple[int, int]] | None:
+    if not (0 <= column_index < len(layout.column_logical_ranges)):
+        return None
+    lstart, lend = layout.column_logical_ranges[column_index]
+    pieces = _decompose_logical_range(
+        lstart, lend, layout.inline_payload_size, layout.overflow_segments
+    )
+    return _resolve_pieces(
+        pieces,
+        payload_start_in_page=layout.payload_start_in_page,
+        page_file_offset=page_file_offset,
+        home_file_kind=home_file_kind,
+        page_locator=page_locator,
+    )
+
+
+def locate_cell(
+    db_path: Path,
+    table_name: str,
+    rowid: int,
+    column_index: int | None,
+    page_size: int,
+    page_table_map: dict[int, str],
+    wal_data: bytes | None,
+) -> CellLocation | None:
+    """Find a live row's (and optionally one column's) exact on-disk byte
+    range(s).
+
+    The row may currently live in the base file or, if not yet
+    checkpointed, only in a committed -wal frame; whichever it is, ranges
+    are returned against *that* file (CellLocation.file_kind), never
+    guessed against the other one. Returns None if the row can't be found
+    on any page *page_table_map* attributes to *table_name* (e.g. the map
+    is stale, or the table has no rowid).
+    """
+    if db_path is None or page_size <= 0:
+        return None
+
+    wal_index = build_wal_page_index(wal_data, page_size)
+    page_locator, read_page = _page_accessors(db_path, page_size, wal_index)
+
+    table_pages = [pn for pn, name in page_table_map.items() if name == table_name]
+
+    for page_num in table_pages:
+        page = read_page(page_num)
+        if page is None or get_page_type(page) != PAGE_TYPE_TABLE_LEAF:
+            continue
+        located = page_locator(page_num)
+        if located is None:
+            continue
+        home_file_kind, page_file_offset = located
+
+        parsed = parse_table_leaf_page(
+            page, page_size=page_size, overflow_reader=read_page, want_ranges=True
+        )
+        if not parsed:
+            continue
+
+        for entry_rowid, _values, layout in parsed:
+            if entry_rowid != rowid:
+                continue
+
+            row_ranges = _row_ranges_from_layout(layout, page_file_offset, home_file_kind, page_locator)
+            column_ranges = (
+                _column_ranges_from_layout(
+                    layout, column_index, page_file_offset, home_file_kind, page_locator
+                )
+                if column_index is not None
+                else None
+            )
+
+            return CellLocation(
+                file_kind=home_file_kind, row_ranges=row_ranges, column_ranges=column_ranges
+            )
+
+    return None
+
+
+def locate_offset(
+    db_path: Path,
+    table_name: str,
+    offset: int,
+    file_kind: str,
+    page_size: int,
+    page_table_map: dict[int, str],
+    wal_data: bytes | None,
+) -> tuple[int, int | None] | None:
+    """Reverse of locate_cell(): given a byte *offset* the caller knows is
+    relative to *file_kind* ("base" or "wal" -- whichever file a Hex pane
+    is currently displaying raw, unmerged bytes of), find which row -- and,
+    if the offset falls inside one specific column's own bytes, which
+    column -- of *table_name* it belongs to.
+
+    Cheaper than locate_cell(): resolves the one page the offset falls on
+    directly, rather than scanning every page of the table. Returns None if
+    the offset doesn't land on a table-leaf page *page_table_map*
+    attributes to *table_name* -- never guesses a nearby/likely row.
+
+    "base" mode reads strictly from the base file (see _raw_base_accessors)
+    -- what the Hex pane shows there is the base file's own bytes, so
+    decoding must never silently substitute a -wal-overridden version of a
+    page, which could have different field lengths and shift every range.
+    "wal" mode resolves the specific frame *offset* falls in (a page can
+    have multiple frames across a WAL file's history; only the latest is
+    resolvable here, same "current version" semantics as locate_cell()) and
+    otherwise reads like locate_cell() (preferring -wal versions of any
+    overflow pages visited too), since a WAL frame's payload can legitimately
+    reference not-yet-superseded overflow pages either way.
+    """
+    if db_path is None or page_size <= 0:
+        return None
+
+    wal_index = build_wal_page_index(wal_data, page_size)
+
+    page_num: int | None = None
+    page_file_offset = 0
+    if file_kind == "wal":
+        for pn, (frame_offset, _data) in wal_index.items():
+            if frame_offset <= offset < frame_offset + page_size:
+                page_num = pn
+                page_file_offset = frame_offset
+                break
+        page_locator, read_page = _page_accessors(db_path, page_size, wal_index)
+    else:
+        candidate = offset // page_size + 1
+        page_num = candidate
+        page_file_offset = (candidate - 1) * page_size
+        page_locator, read_page = _raw_base_accessors(db_path, page_size)
+
+    if page_num is None or page_table_map.get(page_num) != table_name:
+        return None
+
+    page = read_page(page_num)
+    if page is None or get_page_type(page) != PAGE_TYPE_TABLE_LEAF:
+        return None
+
+    parsed = parse_table_leaf_page(
+        page, page_size=page_size, overflow_reader=read_page, want_ranges=True
+    )
+    if not parsed:
+        return None
+
+    for entry_rowid, _values, layout in parsed:
+        row_ranges = _row_ranges_from_layout(layout, page_file_offset, file_kind, page_locator)
+        if not any(start <= offset < end for start, end in row_ranges):
+            continue
+
+        column_index: int | None = None
+        for idx in range(len(layout.column_logical_ranges)):
+            col_ranges = _column_ranges_from_layout(
+                layout, idx, page_file_offset, file_kind, page_locator
+            )
+            if col_ranges and any(s <= offset < e for s, e in col_ranges):
+                column_index = idx
+                break
+
+        return entry_rowid, column_index
+
+    return None

--- a/crush/parsers/sqlite_parser.py
+++ b/crush/parsers/sqlite_parser.py
@@ -270,15 +270,33 @@ class SQLiteParser(AbstractParser):
 
             for table in tables:
                 try:
-                    cursor.execute(f"SELECT * FROM [{table}] LIMIT {_ROW_LIMIT + 1}")  # noqa: S608
-                    raw_rows = cursor.fetchall()
+                    # Fetch each row's rowid alongside its columns -- needed
+                    # by the table viewer's "Locate in Hex" action to find
+                    # the row's exact on-disk bytes later. WITHOUT ROWID
+                    # tables and views raise "no such column: rowid"; fall
+                    # back to the plain query for those, with rowids=None
+                    # (the action simply isn't offered for such rows).
+                    rowids: list[int] | None
+                    try:
+                        cursor.execute(
+                            f"SELECT rowid, * FROM [{table}] LIMIT {_ROW_LIMIT + 1}"  # noqa: S608
+                        )
+                        raw_rows = cursor.fetchall()
+                        rowids = [r[0] for r in raw_rows[:_ROW_LIMIT]]
+                        rows = [list(r)[1:] for r in raw_rows[:_ROW_LIMIT]]
+                        columns = [desc[0] for desc in cursor.description or []][1:]
+                    except Exception:
+                        cursor.execute(f"SELECT * FROM [{table}] LIMIT {_ROW_LIMIT + 1}")  # noqa: S608
+                        raw_rows = cursor.fetchall()
+                        rowids = None
+                        rows = [list(r) for r in raw_rows[:_ROW_LIMIT]]
+                        columns = [desc[0] for desc in cursor.description or []]
                     was_truncated = len(raw_rows) > _ROW_LIMIT
-                    rows = [list(r) for r in raw_rows[:_ROW_LIMIT]]
-                    columns = [desc[0] for desc in cursor.description or []]
                     data[table] = {
                         "columns": columns,
                         "rows": rows,
                         "truncated": was_truncated,
+                        "rowids": rowids,
                     }
                     if was_truncated:
                         truncated_tables.append(table)

--- a/crush/viewers/table_viewer.py
+++ b/crush/viewers/table_viewer.py
@@ -69,6 +69,8 @@ from crush.core.sqlite_unallocated import scan_database_unallocated
 from crush.core.sqlite_wal import (
     build_page_table_map,
     build_wal_page_overlay,
+    locate_cell,
+    locate_offset,
     parse_table_leaf_page,
 )
 from crush.core.ts_decode import TS_FORMATS as _TS_FORMATS
@@ -81,12 +83,18 @@ from crush.core.work_priority import (
 from crush.ui.busy_dialog import run_with_busy_dialog
 from crush.ui.wheel_scroll import install_horizontal_wheel_scroll
 from crush.viewers.blob_inspector import BlobInspector
+from crush.viewers.hex_viewer import HexViewer
 
 
 _MAX_COL_WIDTH = 400
 _QUERY_ROW_LIMIT = 10_000
 _COLUMN_SIZE_SAMPLE = 250
 _VIRTUAL_PATH_BAD_CHARS = re.compile(r"[\\/:\x00-\x1f]+")
+
+# Custom role (distinct from the plain UserRole already used for the "Row"
+# column's display index) storing a real table row's SQLite rowid, when
+# known -- see _append_row()'s rowid param and the embedded Hex pane.
+_ROWID_ROLE = Qt.ItemDataRole.UserRole + 1
 
 
 def _virtual_path_component(value: object, fallback: str) -> str:
@@ -548,6 +556,9 @@ class TableViewer(QWidget):
         self._unallocated_cache: list[dict] | None = None
         self._page_table_map: dict[int, str] = {}  # page_num → table_name
         self._table_interaction_active = False
+        self._hex_pane_loaded = False
+        self._hex_file_kind: str | None = None  # "base" or "wal" -- whichever is currently loaded
+        self._syncing_hex_selection = False
         self._build_ui()
         if data:
             table_names = [k for k in data.keys() if not k.startswith("__")]
@@ -641,6 +652,10 @@ class TableViewer(QWidget):
         self._search.setFixedWidth(200)
         self._search.textChanged.connect(self._apply_filter)
         toolbar_layout.addWidget(self._search)
+
+        self._hex_toggle_btn = QPushButton("Show Hex")
+        self._hex_toggle_btn.clicked.connect(self._toggle_hex_pane)
+        toolbar_layout.addWidget(self._hex_toggle_btn)
 
         layout.addWidget(toolbar)
 
@@ -764,7 +779,32 @@ class TableViewer(QWidget):
         splitter.setStretchFactor(1, 1)
         splitter.setStretchFactor(2, 0)
         splitter.setSizes([140, 500, 80])
-        layout.addWidget(splitter, stretch=1)
+
+        # Embedded, bidirectional Hex pane -- same "Show Hex" toggle
+        # convention as TreeViewer/ProtobufTreeWidget, hidden until toggled
+        # on and loaded lazily then (see _ensure_hex_pane_loaded). The
+        # label above it names which physical file's bytes are currently
+        # loaded -- a row whose current version is only in a not-yet-
+        # checkpointed -wal frame switches the pane to that file instead of
+        # ever implying the base file's (stale) bytes are it.
+        self._hex_panel = QWidget()
+        hex_panel_layout = QVBoxLayout(self._hex_panel)
+        hex_panel_layout.setContentsMargins(0, 0, 0, 0)
+        hex_panel_layout.setSpacing(2)
+        self._hex_file_label = QLabel("")
+        self._hex_file_label.setStyleSheet("color: gray; font-size: 11px;")
+        hex_panel_layout.addWidget(self._hex_file_label)
+        self._hex_viewer = HexViewer(b"")
+        self._hex_viewer.byteOffsetFocused.connect(self._on_hex_offset_focused)
+        hex_panel_layout.addWidget(self._hex_viewer, stretch=1)
+        self._hex_panel.setVisible(False)
+
+        hex_splitter = QSplitter(Qt.Orientation.Horizontal)
+        hex_splitter.addWidget(splitter)
+        hex_splitter.addWidget(self._hex_panel)
+        hex_splitter.setStretchFactor(0, 1)
+        hex_splitter.setStretchFactor(1, 1)
+        layout.addWidget(hex_splitter, stretch=1)
 
         self._table_view.selectionModel().currentChanged.connect(
             self._on_current_cell_changed
@@ -879,6 +919,9 @@ class TableViewer(QWidget):
         self._col_ts_formats.clear()
         columns: list[str] = table["columns"]
         rows: list[list[Any]] = table["rows"]
+        rowids: list[int] | None = table.get("rowids")
+        if rowids is not None and len(rowids) != len(rows):
+            rowids = None  # defensive: should always line up 1:1 with rows
 
         self._reset_source_model()
         show_wal = has_wal and self._wal_toggle.isChecked()
@@ -889,11 +932,13 @@ class TableViewer(QWidget):
         self._source_model.setHorizontalHeaderLabels(headers)
 
         def _append_row(row_data: list[Any], source_label: str | None = None,
-                        row_color: object = None) -> None:
+                        row_color: object = None, rowid: int | None = None) -> None:
             row_index = self._source_model.rowCount() + 1
             row_item = QStandardItem(str(row_index))
             row_item.setEditable(False)
             row_item.setData(row_index, Qt.ItemDataRole.UserRole)
+            if rowid is not None:
+                row_item.setData(rowid, _ROWID_ROLE)
             if row_color:
                 row_item.setForeground(row_color)
             items = [row_item]
@@ -966,13 +1011,14 @@ class TableViewer(QWidget):
             _added_color = QColor("#228833")
             for r, row_data in enumerate(rows):
                 objkey = active_obj_keys[r] if r < len(active_obj_keys) else None
+                rowid = rowids[r] if rowids is not None else None
                 if objkey is not None and objkey not in prev_obj_keys_set:
-                    _append_row(row_data, "added", _added_color)
+                    _append_row(row_data, "added", _added_color, rowid=rowid)
                 else:
-                    _append_row(row_data)
+                    _append_row(row_data, rowid=rowid)
         else:
-            for row_data in rows:
-                _append_row(row_data)
+            for r, row_data in enumerate(rows):
+                _append_row(row_data, rowid=rowids[r] if rowids is not None else None)
 
         wal_row_count = 0
         if show_wal:
@@ -1462,6 +1508,26 @@ class TableViewer(QWidget):
         except Exception:
             self._db_page_size = 0
         return self._db_page_size
+
+    def _ensure_page_table_map(self) -> dict[int, str]:
+        """Return (and cache) self._page_table_map, building it on demand.
+
+        _get_wal_frames() also populates it, but only as a side effect of a
+        live -wal file existing — most forensic SQLite files have long
+        since been checkpointed and have no -wal sidecar, so the embedded
+        Hex pane's sync can't rely on that path alone.
+        """
+        if self._page_table_map:
+            return self._page_table_map
+        page_size = self._get_page_size()
+        conn = self._ensure_db()
+        if conn is None or page_size == 0:
+            return self._page_table_map
+        try:
+            self._page_table_map = build_page_table_map(conn, self._get_wal_data(), page_size)
+        except Exception:
+            pass
+        return self._page_table_map
 
     def _get_freelist_data(self) -> tuple[list[dict], list[dict]]:
         """Return (and cache) (freelist entries, carved leftover rows)."""
@@ -2731,6 +2797,8 @@ class TableViewer(QWidget):
         if not current.isValid():
             self._cell_detail_label.setText("—  No cell selected")
             self._cell_detail_view.setPlainText("")
+            if not self._syncing_hex_selection:
+                self._sync_hex_pane(None)
             return
 
         col = current.column()
@@ -2756,6 +2824,134 @@ class TableViewer(QWidget):
                 self._cell_detail_view.setPlainText(preview)
         else:
             self._cell_detail_view.setPlainText(display_str)
+
+        if not self._syncing_hex_selection:
+            self._sync_hex_pane(current)
+
+    def _is_pseudo_table(self, table_name: str) -> bool:
+        return table_name in (
+            self._summary_label, self._db_structure_label, self._db_info_label,
+            self._wal_label, self._freelist_label, self._freeblocks_label,
+            self._unallocated_label,
+        )
+
+    def _toggle_hex_pane(self) -> None:
+        visible = not self._hex_panel.isVisible()
+        self._hex_panel.setVisible(visible)
+        self._hex_toggle_btn.setText("Hide Hex" if visible else "Show Hex")
+        if visible:
+            self._ensure_hex_pane_loaded()
+            self._sync_hex_pane(self._table_view.currentIndex())
+
+    def _ensure_hex_pane_loaded(self) -> None:
+        if self._hex_pane_loaded or self._db_path is None:
+            return
+        try:
+            data = self._db_path.read_bytes()
+        except OSError:
+            return
+        self._hex_viewer.set_data(data)
+        self._hex_file_kind = "base"
+        self._hex_file_label.setText(f"{self._source_name}  ·  db file")
+        self._hex_pane_loaded = True
+
+    def _sync_hex_pane(self, current: QModelIndex | None) -> None:
+        """Table → Hex: highlight the current cell's row (and, when a
+        specific column is selected, that column too, drawn on top) in the
+        embedded Hex pane. Reuses HexViewer.highlight_byte_ranges() as-is
+        (row ranges first so column ranges paint on top of them)."""
+        if not self._hex_panel.isVisible():
+            return
+
+        rowid = None
+        col_idx = None
+        if current is not None and current.isValid():
+            source_index = self._proxy_model.mapToSource(current)
+            row_item = self._source_model.item(source_index.row(), 0)
+            rowid = row_item.data(_ROWID_ROLE) if row_item is not None else None
+            col_idx = current.column() - 1  # column 0 is "Row"
+
+        table_name = self._table_combo.currentText()
+        if (
+            rowid is None or col_idx is None or col_idx < 0
+            or self._is_pseudo_table(table_name)
+            or self._query_results_active
+            or self._db_path is None
+        ):
+            self._hex_viewer.clear_byte_range_highlight()
+            return
+
+        self._ensure_hex_pane_loaded()
+        page_size = self._get_page_size()
+        if page_size == 0:
+            self._hex_viewer.clear_byte_range_highlight()
+            return
+        page_table_map = self._ensure_page_table_map()
+
+        location = locate_cell(
+            self._db_path, table_name, int(rowid), col_idx, page_size,
+            page_table_map, self._get_wal_data(),
+        )
+        if location is None:
+            self._hex_viewer.clear_byte_range_highlight()
+            return
+
+        if location.file_kind != self._hex_file_kind:
+            target_path = (
+                Path(str(self._db_path) + "-wal")
+                if location.file_kind == "wal" else self._db_path
+            )
+            try:
+                data = target_path.read_bytes()
+            except OSError:
+                self._hex_viewer.clear_byte_range_highlight()
+                return
+            self._hex_viewer.set_data(data)
+            self._hex_file_kind = location.file_kind
+            suffix = "-wal file" if location.file_kind == "wal" else "db file"
+            self._hex_file_label.setText(f"{self._source_name}  ·  {suffix}")
+
+        ranges = list(location.row_ranges)
+        if location.column_ranges:
+            ranges.extend(location.column_ranges)
+        self._hex_viewer.highlight_byte_ranges(ranges)
+
+    def _on_hex_offset_focused(self, offset: int) -> None:
+        """Hex → Table: clicking a byte in the pane selects the matching
+        table cell, when resolvable (see locate_offset()'s docstring for
+        the cases it can't -- e.g. a click landing on an overflow-only
+        page -- where this is simply a no-op, never a wrong selection)."""
+        if self._hex_file_kind is None or self._db_path is None:
+            return
+        table_name = self._table_combo.currentText()
+        if self._is_pseudo_table(table_name) or self._query_results_active:
+            return
+        page_size = self._get_page_size()
+        if page_size == 0:
+            return
+        page_table_map = self._ensure_page_table_map()
+
+        result = locate_offset(
+            self._db_path, table_name, offset, self._hex_file_kind, page_size,
+            page_table_map, self._get_wal_data(),
+        )
+        if result is None:
+            return
+        rowid, col_idx = result
+
+        for row in range(self._source_model.rowCount()):
+            row_item = self._source_model.item(row, 0)
+            if row_item is None or row_item.data(_ROWID_ROLE) != rowid:
+                continue
+            target_col = (col_idx + 1) if col_idx is not None else 0
+            source_index = self._source_model.index(row, target_col)
+            proxy_index = self._proxy_model.mapFromSource(source_index)
+            if proxy_index.isValid():
+                self._syncing_hex_selection = True
+                self._table_view.setCurrentIndex(proxy_index)
+                self._table_view.scrollTo(proxy_index)
+                self._syncing_hex_selection = False
+            break
 
     def _on_table_scroll_activity(self, _value: int = 0) -> None:
         if not self._table_interaction_active:


### PR DESCRIPTION
Reuses PR #83's shared HexViewer highlighting API (highlight_byte_ranges/byteOffsetFocused) directly in TableViewer's existing per-cell selection hook, rather than through ByteMappedTreeHex — that widget is built around QTreeView's nested item model and only tracks whole-node granularity, not the per-cell (row+column) precision TableViewer needs.

- sqlite_wal.py: new locate_offset() (reverse of locate_cell()) resolves   a clicked hex byte back to (rowid, column_index) via a single-page   lookup; known limitation documented — an offset landing on an
  overflow-only page can't be attributed (page_table_map only covers a   table's own B-tree pages, not overflow chains), returns None rather   than guessing.
- sqlite_parser.py: threads each row's rowid through   (data[table]["rowids"]), needed to key the lookup.
- table_viewer.py: "Show Hex" toggle (same convention as   TreeViewer/ProtobufTreeWidget), embedded HexViewer pane, switches to   the -wal file when a row's current version lives only there.

Also credits @JamesHabben's PR #83 (embedded Hex pane for Protobuf/Tree Viewer) in CHANGELOG.md,