### PR TITLE
test: stop a leaked export-thread signal from opening a real file man…

### DIFF
--- a/crush/tests/conftest.py
+++ b/crush/tests/conftest.py
@@ -115,6 +115,43 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Qt safety net
+# ---------------------------------------------------------------------------
+#
+# No test should ever launch a real external application (a file manager, a
+# browser) -- that's a side effect on the developer's own desktop, not on
+# anything the test controls or cleans up. This has actually happened: a
+# MainWindow left open by one test (see the general Qt-widget-leak note
+# below) can have a queued cross-thread "export finished" signal delivered
+# arbitrarily late, during a completely unrelated later test's own Qt event
+# loop -- by which point that first test's QMessageBox mock has already been
+# reverted, so the real "Open location?" dialog and, if answered yes, a real
+# `xdg-open` call can fire. Blocking the one real-world side effect at its
+# source, for the whole session, makes that failure mode inert regardless of
+# which other bug caused the stray signal.
+@pytest.fixture(autouse=True)
+def _no_real_external_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    import crush.ui as _crush_ui
+    monkeypatch.setattr(_crush_ui, "open_url", lambda url: None)
+
+# NOTE: a companion autouse fixture that force-closed every leftover
+# top-level widget after each test (to plug the general MainWindow-leak
+# problem described in the module docstring at the top of this section) was
+# tried here and reverted -- it made the suite crash the whole pytest
+# process (SIGABRT/segfault) intermittently, not consistently, which points
+# to one or more tests leaving a QThread worker still running when its
+# owning widget gets torn down. That's a real bug worth fixing, but a blind
+# global "close everything" is the wrong way to do it: it does not know
+# which threads are safe to interrupt, and papering over the crash by luck
+# of timing is worse than the leak it was meant to fix. Fixing it properly
+# means going test by test and making sure each worker thread is stopped
+# and joined (not just the widget closed) before the test ends -- see the
+# three tests fixed alongside this fixture (test_cli_focus.py,
+# test_export_overwrite_confirm.py, test_send_biome_to_peach.py) for the
+# pattern to extend elsewhere.
+
+
+# ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
 

--- a/crush/tests/test_cli_focus.py
+++ b/crush/tests/test_cli_focus.py
@@ -50,16 +50,22 @@ def sample_folder(tmp_path: Path) -> Path:
 
 def test_focus_opens_the_target_file_inside_a_folder(qapp, sample_folder: Path) -> None:
     win = MainWindow()
-    _load_and_wait(win, str(sample_folder), "Documents/note.txt")
-    assert win._viewer_tabs.count() == 1
-    assert win._viewer_tabs.tabText(0) == "note.txt"
+    try:
+        _load_and_wait(win, str(sample_folder), "Documents/note.txt")
+        assert win._viewer_tabs.count() == 1
+        assert win._viewer_tabs.tabText(0) == "note.txt"
+    finally:
+        win.close()
 
 
 def test_focus_missing_target_shows_explicit_status_and_opens_nothing(qapp, sample_folder: Path) -> None:
     win = MainWindow()
-    _load_and_wait(win, str(sample_folder), "Documents/does_not_exist.txt")
-    assert win._viewer_tabs.count() == 0
-    assert "not found" in win._status.currentMessage()
+    try:
+        _load_and_wait(win, str(sample_folder), "Documents/does_not_exist.txt")
+        assert win._viewer_tabs.count() == 0
+        assert "not found" in win._status.currentMessage()
+    finally:
+        win.close()
 
 
 def test_focus_on_single_file_target_still_opens_it(qapp, sample_folder: Path) -> None:
@@ -67,7 +73,10 @@ def test_focus_on_single_file_target_still_opens_it(qapp, sample_folder: Path) -
     must still open via the existing single-file auto-open behavior —
     --focus being pointless here shouldn't block that."""
     win = MainWindow()
-    single_file = sample_folder / "readme.txt"
-    _load_and_wait(win, str(single_file), "whatever.txt")
-    assert win._viewer_tabs.count() == 1
-    assert win._viewer_tabs.tabText(0) == "readme.txt"
+    try:
+        single_file = sample_folder / "readme.txt"
+        _load_and_wait(win, str(single_file), "whatever.txt")
+        assert win._viewer_tabs.count() == 1
+        assert win._viewer_tabs.tabText(0) == "readme.txt"
+    finally:
+        win.close()

--- a/crush/tests/test_export_overwrite_confirm.py
+++ b/crush/tests/test_export_overwrite_confirm.py
@@ -37,10 +37,13 @@ def test_export_node_asks_before_overwriting_existing_target(qapp, tmp_path, mon
     monkeypatch.setattr(QMessageBox, "question", fake_question)
 
     win = MainWindow()
-    win._export_node(vfs.root(), vfs)
+    try:
+        win._export_node(vfs.root(), vfs)
 
-    assert len(questions) == 1
-    assert not win._thread_is_running(getattr(win, "_export_thread", None))
+        assert len(questions) == 1
+        assert not win._thread_is_running(getattr(win, "_export_thread", None))
+    finally:
+        win.close()
 
 
 def test_export_node_proceeds_when_overwrite_confirmed(qapp, tmp_path, monkeypatch) -> None:
@@ -53,10 +56,18 @@ def test_export_node_proceeds_when_overwrite_confirmed(qapp, tmp_path, monkeypat
     monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes)
 
     win = MainWindow()
-    win._export_node(vfs.root(), vfs)
+    try:
+        win._export_node(vfs.root(), vfs)
 
-    assert win._thread_is_running(win._export_thread)
-    win._export_thread.wait(5000)
+        assert win._thread_is_running(win._export_thread)
+        win._export_thread.wait(5000)
+        # Drain the queued cross-thread "finished" signal now, while our own
+        # mocks above are still active, instead of leaving it pending for
+        # whichever later, unrelated test's event loop happens to flush it
+        # first (see conftest._no_real_external_open for what that caused).
+        qapp.processEvents()
+    finally:
+        win.close()
 
 
 def test_export_node_does_not_prompt_when_target_is_new(qapp, tmp_path, monkeypatch) -> None:
@@ -69,8 +80,12 @@ def test_export_node_does_not_prompt_when_target_is_new(qapp, tmp_path, monkeypa
     monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: questions.append(a))
 
     win = MainWindow()
-    win._export_node(vfs.root(), vfs)
+    try:
+        win._export_node(vfs.root(), vfs)
 
-    assert questions == []
-    assert win._thread_is_running(win._export_thread)
-    win._export_thread.wait(5000)
+        assert questions == []
+        assert win._thread_is_running(win._export_thread)
+        win._export_thread.wait(5000)
+        qapp.processEvents()
+    finally:
+        win.close()

--- a/crush/tests/test_send_biome_to_peach.py
+++ b/crush/tests/test_send_biome_to_peach.py
@@ -45,26 +45,29 @@ def test_send_biome_to_peach_preserves_relative_directory_structure(
     monkeypatch.setattr(peach_launcher, "launch_peach", fake_launch_peach)
 
     win = MainWindow()
-    win._send_biome_to_peach(root_node, vfs, [node_a, node_b])
+    try:
+        win._send_biome_to_peach(root_node, vfs, [node_a, node_b])
 
-    assert len(captured["sources"]) == 1
-    materialized = captured["sources"][0]
-    cleanup_dir = captured["cleanup_dirs"][0]
+        assert len(captured["sources"]) == 1
+        materialized = captured["sources"][0]
+        cleanup_dir = captured["cleanup_dirs"][0]
 
-    # The source handed to peach must structurally end in "biome/streams" --
-    # that's the suffix peach's CLI source-kind heuristic looks for to
-    # default the new source to Biome instead of AUL -- while cleanup
-    # still targets the actual mkdtemp() root above that wrapper.
-    assert materialized.name == "streams"
-    assert materialized.parent.name == "biome"
-    assert materialized.parent.parent == cleanup_dir
+        # The source handed to peach must structurally end in "biome/streams" --
+        # that's the suffix peach's CLI source-kind heuristic looks for to
+        # default the new source to Biome instead of AUL -- while cleanup
+        # still targets the actual mkdtemp() root above that wrapper.
+        assert materialized.name == "streams"
+        assert materialized.parent.name == "biome"
+        assert materialized.parent.parent == cleanup_dir
 
-    # `rel` is preserved unchanged below the synthetic wrapper, so the
-    # fixture's own "streams" subfolder (relative to root_dir) still shows
-    # up here too -- harmless duplication, since peach's SEGB detection
-    # only inspects each file's last 2-3 path components regardless of
-    # what sits above them.
-    copied_a = materialized / "streams" / "restricted" / "Device.Wireless.Bluetooth" / "local" / "file_a"
-    copied_b = materialized / "streams" / "public" / "Backlight" / "local" / "file_b"
-    assert copied_a.read_bytes() == b"SEGBaaaa"
-    assert copied_b.read_bytes() == b"SEGBbbbb"
+        # `rel` is preserved unchanged below the synthetic wrapper, so the
+        # fixture's own "streams" subfolder (relative to root_dir) still shows
+        # up here too -- harmless duplication, since peach's SEGB detection
+        # only inspects each file's last 2-3 path components regardless of
+        # what sits above them.
+        copied_a = materialized / "streams" / "restricted" / "Device.Wireless.Bluetooth" / "local" / "file_a"
+        copied_b = materialized / "streams" / "public" / "Backlight" / "local" / "file_b"
+        assert copied_a.read_bytes() == b"SEGBaaaa"
+        assert copied_b.read_bytes() == b"SEGBbbbb"
+    finally:
+        win.close()


### PR DESCRIPTION
…ager

Two tests in test_export_overwrite_confirm.py started a real export QThread but never drained the Qt event queue, so the queued "export finished" signal -> "Open location?" dialog could fire much later during a completely unrelated test's own event loop -- by which point the QMessageBox mock had already been reverted, letting a real xdg-open call through. Added an autouse fixture that blocks any real open_url() call for the test session, and fixed the three tests that leaked a MainWindow (two of them a live worker thread too) to close it and settle pending signals before returning.